### PR TITLE
Draw sorts from the skeleton graph

### DIFF
--- a/headers/GProcess.h
+++ b/headers/GProcess.h
@@ -10,7 +10,7 @@
 /**
   * @file GProcess.h
   * @brief header for the GProcess class
-  * @author PAPPL_2012
+  * @author PAPPL_2013
   *
   */
 
@@ -38,6 +38,16 @@ class GProcess {
           */
         GProcess(ProcessPtr p, GVNode n, qreal graphDPI);
 
+        /**
+          * @brief constructor
+          *
+          * @param ProcessPtr the related Process object
+          * @param double centerX position of the center of the ellipse in the x axis
+          * @param double centerY position of the center of the ellipse in the y axis
+          * @param double width width of the ellipse
+          * @param double height height of the ellipse
+
+          */
 	GProcess(ProcessPtr p,double centerX, double centerY, double width, double height);
 
 		~GProcess();

--- a/headers/GProcess.h~
+++ b/headers/GProcess.h~
@@ -38,7 +38,7 @@ class GProcess {
           */
         GProcess(ProcessPtr p, GVNode n, qreal graphDPI);
 
-	GProcess(ProcessPtr p,double centerX, double centerY, double width, double height);
+	GProcess(ProcessPtr p,double xCornerPos, double yCornerPos, double width, double height);
 
 		~GProcess();
 

--- a/headers/GProcess.h~
+++ b/headers/GProcess.h~
@@ -10,7 +10,7 @@
 /**
   * @file GProcess.h
   * @brief header for the GProcess class
-  * @author PAPPL_2012
+  * @author PAPPL_2014
   *
   */
 
@@ -38,7 +38,17 @@ class GProcess {
           */
         GProcess(ProcessPtr p, GVNode n, qreal graphDPI);
 
-	GProcess(ProcessPtr p,double xCornerPos, double yCornerPos, double width, double height);
+        /**
+          * @brief constructor
+          *
+          * @param ProcessPtr the related Process object
+          * @param double centerX position of the center of the ellipse in the x axis
+          * @param double centerY position of the center of the ellipse in the y axis
+          * @param double width width of the ellipse
+          * @param double height height of the ellipse
+
+          */
+	GProcess(ProcessPtr p,double centerX, double centerY, double width, double height);
 
 		~GProcess();
 

--- a/headers/GSimpleProcess.h
+++ b/headers/GSimpleProcess.h
@@ -1,0 +1,130 @@
+#pragma once
+#include <QGraphicsItem>
+#include <QGraphicsEllipseItem>
+#include <QGraphicsTextItem>
+#include <list>
+#include "PH.h"
+#include "Process.h"
+
+/**
+  * @file GProcess.h
+  * @brief header for the GProcess class
+  * @author PAPPL_2012
+  *
+  */
+
+class GSimpleProcess;
+typedef boost::shared_ptr<GSimpleProcess> GSimpleProcessPtr;
+class Process;
+typedef boost::shared_ptr<Process> ProcessPtr;
+
+
+/**
+  * @class GProcess
+  * @brief contains style and layout info to draw a process
+  *
+  */
+class GSimpleProcess {
+
+	public:
+
+        /**
+          * @brief constructor
+          *
+          * @param ProcessPtr the related Process object
+          * @param GVNode the object that contains style and layout info
+          * @param qreal graph DPI value (graphviz)
+          */
+
+	GSimpleProcess(ProcessPtr p, double centerX, double centerY, double width, double height);
+
+		~GSimpleProcess();
+
+        /**
+          * @brief gets the display
+          *
+          * @return QGraphicsItem the graphical item representing the Process
+          */
+		QGraphicsItem* getDisplayItem (void);
+
+        /**
+          * @brief gets the ellipse
+          *
+          */
+        QGraphicsEllipseItem* getEllipseItem();
+
+        /**
+          * @brief gets the related GVNode
+          *
+          * @return the related GVNode
+          */
+        GVNode* getNode();
+
+        /**
+          * @brief gets the rect item that represents the margin of this GProcess
+          *
+          */
+        QGraphicsRectItem* getMarginRect();
+        
+        /**
+          * @brief checks collisions with margins of other GProcess items (see graph attribute "sep" in GVSubGraph)
+          *
+          * @return bool true if this GProcess' margin collides with another one's margin (of a different sort), else false
+          */
+        bool checkCollisions();
+
+
+        /**
+          * @brief gets the related Process
+          *
+          */
+
+        ProcessPtr* getProcess();
+
+
+	
+	protected:
+
+        /**
+          * @brief the graphical item representing the Process
+          *
+          */
+		QGraphicsItem* display;
+
+        /**
+          * @brief the graphical item representing the ellipse of the Process
+          *
+          */
+		QGraphicsEllipseItem* ellipse;
+
+        /**
+          * @brief the graphical item representing the text of the Process
+          *
+          */
+        QGraphicsTextItem* text;
+
+        /**
+          * @brief the related Process
+          *
+          */
+		ProcessPtr process;
+
+        /**
+          * @brief the margin around this process, must exclude any other process' margin (cf. graphviz attribute "pos" in GVSubGraph)
+          *
+          */
+        QGraphicsRectItem* marginRect;
+
+        /**
+          * @brief arbitrarily-chosen key for "margin item" data
+          *
+          */
+        static const int marginZone;
+
+        /**
+          * @brief arbitrarily-chosen key for sort name data
+          *
+          */
+        static const int sortName;
+
+};

--- a/headers/GSimpleProcess.h~
+++ b/headers/GSimpleProcess.h~
@@ -1,0 +1,130 @@
+#pragma once
+#include <QGraphicsItem>
+#include <QGraphicsEllipseItem>
+#include <QGraphicsTextItem>
+#include <list>
+#include "PH.h"
+#include "Process.h"
+
+/**
+  * @file GProcess.h
+  * @brief header for the GProcess class
+  * @author PAPPL_2012
+  *
+  */
+
+class GProcess;
+typedef boost::shared_ptr<GSimpleProcess> GSimpleProcessPtr;
+class Process;
+typedef boost::shared_ptr<Process> ProcessPtr;
+
+
+/**
+  * @class GProcess
+  * @brief contains style and layout info to draw a process
+  *
+  */
+class GSimpleProcess {
+
+	public:
+
+        /**
+          * @brief constructor
+          *
+          * @param ProcessPtr the related Process object
+          * @param GVNode the object that contains style and layout info
+          * @param qreal graph DPI value (graphviz)
+          */
+
+	GSimpleProcess(ProcessPtr p, double centerX, double centerY, double width, double height);
+
+		~GSimpleProcess();
+
+        /**
+          * @brief gets the display
+          *
+          * @return QGraphicsItem the graphical item representing the Process
+          */
+		QGraphicsItem* getDisplayItem (void);
+
+        /**
+          * @brief gets the ellipse
+          *
+          */
+        QGraphicsEllipseItem* getEllipseItem();
+
+        /**
+          * @brief gets the related GVNode
+          *
+          * @return the related GVNode
+          */
+        GVNode* getNode();
+
+        /**
+          * @brief gets the rect item that represents the margin of this GProcess
+          *
+          */
+        QGraphicsRectItem* getMarginRect();
+        
+        /**
+          * @brief checks collisions with margins of other GProcess items (see graph attribute "sep" in GVSubGraph)
+          *
+          * @return bool true if this GProcess' margin collides with another one's margin (of a different sort), else false
+          */
+        bool checkCollisions();
+
+
+        /**
+          * @brief gets the related Process
+          *
+          */
+
+        ProcessPtr* getProcess();
+
+
+	
+	protected:
+
+        /**
+          * @brief the graphical item representing the Process
+          *
+          */
+		QGraphicsItem* display;
+
+        /**
+          * @brief the graphical item representing the ellipse of the Process
+          *
+          */
+		QGraphicsEllipseItem* ellipse;
+
+        /**
+          * @brief the graphical item representing the text of the Process
+          *
+          */
+        QGraphicsTextItem* text;
+
+        /**
+          * @brief the related Process
+          *
+          */
+		ProcessPtr process;
+
+        /**
+          * @brief the margin around this process, must exclude any other process' margin (cf. graphviz attribute "pos" in GVSubGraph)
+          *
+          */
+        QGraphicsRectItem* marginRect;
+
+        /**
+          * @brief arbitrarily-chosen key for "margin item" data
+          *
+          */
+        static const int marginZone;
+
+        /**
+          * @brief arbitrarily-chosen key for sort name data
+          *
+          */
+        static const int sortName;
+
+};

--- a/headers/GSort.h
+++ b/headers/GSort.h
@@ -8,7 +8,6 @@
 #include "GVCluster.h"
 #include "GVNode.h"
 #include "GProcess.h"
-#include "GSimpleProcess.h"
 
 /**
   * @file GSort.h

--- a/headers/GSort.h
+++ b/headers/GSort.h
@@ -31,7 +31,7 @@ class GSort : public QGraphicsRectItem {
 
 	public:
 
-        /**
+        /** 
           * @brief constructor
           *
           * @param SortPtr the related Sort object
@@ -39,6 +39,14 @@ class GSort : public QGraphicsRectItem {
           */
 		GSort(SortPtr p, GVCluster c);
 
+        /**
+          * @brief constructor
+          *
+          * @param SortPtr the related Sort object
+
+          * @param GVNode the node of the skeleton graph containing layout info
+
+          */
 		GSort(SortPtr p, GVNode n);
 
 		~GSort();
@@ -152,6 +160,13 @@ class GSort : public QGraphicsRectItem {
           *
           */
 		SortPtr sort;
+
+        /**
+          * @brief list of GProcessPtr contained by the sort
+
+          *
+
+          */
 		vector<GProcessPtr> gProcesses;
 
         /**

--- a/headers/GSort.h
+++ b/headers/GSort.h
@@ -2,11 +2,13 @@
 #include <QGraphicsRectItem>
 #include <QGraphicsTextItem>
 #include <QColor>
-#include <list>
+#include <vector>
 #include "PH.h"
 #include "Sort.h"
 #include "GVCluster.h"
 #include "GVNode.h"
+#include "GProcess.h"
+#include "GSimpleProcess.h"
 
 /**
   * @file GSort.h
@@ -17,6 +19,8 @@
 
 class GSort;
 typedef boost::shared_ptr<GSort> GSortPtr;
+class GSimpleProcess;
+typedef boost::shared_ptr<GProcess> GProcessPtr;
 
 
 /**
@@ -39,6 +43,7 @@ class GSort : public QGraphicsRectItem {
 		GSort(SortPtr p, GVNode n);
 
 		~GSort();
+
 
         /**
           * @brief get the rect item
@@ -148,6 +153,7 @@ class GSort : public QGraphicsRectItem {
           *
           */
 		SortPtr sort;
+		vector<GProcessPtr> gProcesses;
 
         /**
           * @brief the related cluster

--- a/headers/GSort.h~
+++ b/headers/GSort.h~
@@ -153,9 +153,7 @@ class GSort : public QGraphicsRectItem {
           * @brief the related cluster
           *
           */
-		GVCluster cluster;
-
-		GVNode node;		
+		GVCluster cluster;		
 		
         /**
           * @brief the palette of colors that may be used as color member

--- a/headers/GSort.h~
+++ b/headers/GSort.h~
@@ -7,6 +7,8 @@
 #include "Sort.h"
 #include "GVCluster.h"
 #include "GVNode.h"
+#include "GProcess.h"
+#include "GSimpleProcess.h"
 
 /**
   * @file GSort.h
@@ -17,6 +19,8 @@
 
 class GSort;
 typedef boost::shared_ptr<GSort> GSortPtr;
+class GSimpleProcess;
+typedef boost::shared_ptr<GProcess> GProcessPtr;
 
 
 /**
@@ -39,6 +43,7 @@ class GSort : public QGraphicsRectItem {
 		GSort(SortPtr p, GVNode n);
 
 		~GSort();
+
 
         /**
           * @brief get the rect item
@@ -148,12 +153,15 @@ class GSort : public QGraphicsRectItem {
           *
           */
 		SortPtr sort;
+		vector<GProcessPtr> gProcesses;
 
         /**
           * @brief the related cluster
           *
           */
-		GVCluster cluster;		
+		GVCluster cluster;
+
+		GVNode node;		
 		
         /**
           * @brief the palette of colors that may be used as color member

--- a/headers/GSort.h~
+++ b/headers/GSort.h~
@@ -8,7 +8,6 @@
 #include "GVCluster.h"
 #include "GVNode.h"
 #include "GProcess.h"
-#include "GSimpleProcess.h"
 
 /**
   * @file GSort.h
@@ -32,7 +31,7 @@ class GSort : public QGraphicsRectItem {
 
 	public:
 
-        /**
+        /** 
           * @brief constructor
           *
           * @param SortPtr the related Sort object
@@ -40,6 +39,14 @@ class GSort : public QGraphicsRectItem {
           */
 		GSort(SortPtr p, GVCluster c);
 
+        /**
+          * @brief constructor
+          *
+          * @param SortPtr the related Sort object
+
+          * @param GVNode the node of the skeleton graph containing layout info
+
+          */
 		GSort(SortPtr p, GVNode n);
 
 		~GSort();
@@ -153,6 +160,13 @@ class GSort : public QGraphicsRectItem {
           *
           */
 		SortPtr sort;
+
+        /**
+          * @brief the related Sort
+
+          *
+
+          */
 		vector<GProcessPtr> gProcesses;
 
         /**

--- a/headers/GSort.h~
+++ b/headers/GSort.h~
@@ -2,7 +2,7 @@
 #include <QGraphicsRectItem>
 #include <QGraphicsTextItem>
 #include <QColor>
-#include <list>
+#include <vector>
 #include "PH.h"
 #include "Sort.h"
 #include "GVCluster.h"

--- a/headers/PHScene.h
+++ b/headers/PHScene.h
@@ -11,6 +11,7 @@
 #include "GVSkeletonGraph.h"
 
 
+
 /**
   * @file PHScene.h
   * @brief header for the PHScene class

--- a/headers/PHScene.h~
+++ b/headers/PHScene.h~
@@ -8,6 +8,8 @@
 #include "GProcess.h"
 #include "GSort.h"
 #include "GVGraph.h"
+#include "GVSkeletonGraph.h"
+
 
 
 /**
@@ -24,6 +26,8 @@ using std::string;
 class PH;
 class GProcess;
 typedef boost::shared_ptr<GProcess> GProcessPtr;
+class GSimpleProcess;
+typedef boost::shared_ptr<GSimpleProcess> GSimpleProcessPtr;
 class GSort;
 typedef boost::shared_ptr<GSort> GSortPtr;
 class GAction;

--- a/headers/PHScene.h~
+++ b/headers/PHScene.h~
@@ -8,7 +8,6 @@
 #include "GProcess.h"
 #include "GSort.h"
 #include "GVGraph.h"
-#include "GVSkeletonGraph.h"
 
 
 /**

--- a/src/gfx/GProcess.cpp~
+++ b/src/gfx/GProcess.cpp~
@@ -51,7 +51,7 @@ GProcess::GProcess(ProcessPtr p,double centerX, double centerY, double width, do
     display = new QGraphicsItemGroup();
 
     // ellipse
-    ellipse = new QGraphicsEllipseItem (centerX-width/2, centerY-height/2,
+    ellipse = new QGraphicsEllipseItem (centerX, centerY,
                                         width, height, display);
 	ellipse->setPen(QPen(QColor(238,232,213)));
 	ellipse->setBrush(QBrush(QColor(238,232,213)));

--- a/src/gfx/GSimpleProcess.cpp
+++ b/src/gfx/GSimpleProcess.cpp
@@ -1,0 +1,83 @@
+#include <iostream>
+#include <QPen>
+#include <QColor>
+#include <QBrush>
+#include <QSizeF>
+#include <QTextDocument>
+#include <Qt>
+#include "GSimpleProcess.h"
+#include <math.h>
+
+
+const int GSimpleProcess::marginZone  = 10;
+const int GSimpleProcess::sortName    = 11;
+
+GSimpleProcess::GSimpleProcess(ProcessPtr p, double centerX, double centerY, double width, double height): process(p) {
+
+    display = new QGraphicsItemGroup();
+
+    // ellipse
+    ellipse = new QGraphicsEllipseItem (centerX, centerY,
+                                        width, height, display);
+	ellipse->setPen(QPen(QColor(238,232,213)));
+	ellipse->setBrush(QBrush(QColor(238,232,213)));
+
+/* 
+    //int margin( (int) ceil(GVSubGraph::sepValue * graphDPI / GVGraph::DotDefaultDPI) );
+    int margin = 30;
+    marginRect = new QGraphicsRectItem(
+                centerX -width/2 - margin,
+                centerY - height/2 - margin,
+                width + 2*margin,
+                height + 2*margin,
+                display);
+                
+    marginRect->setBrush(Qt::NoBrush);
+    marginRect->setPen(Qt::NoPen);
+    marginRect->setData(marginZone, true);
+    marginRect->setData(sortName, process->getSort()->getName().c_str());
+    
+    // text
+    text = new QGraphicsTextItem (QString("%1").arg(process->getNumber()), ellipse);
+    text->setDefaultTextColor(QColor(7,54,66));
+    text->setPos(centerX, centerY);
+
+    // position the text
+	QSizeF textSize = text->document()->size();
+	text->setPos(text->x() - textSize.width()/2, text->y() - textSize.height()/2);
+*/
+}
+
+
+GSimpleProcess::~GSimpleProcess() {
+    delete ellipse;
+    delete text;
+	delete display;
+}
+
+
+// getters
+
+QGraphicsItem* GSimpleProcess::getDisplayItem (void) { return display; }
+
+QGraphicsEllipseItem* GSimpleProcess::getEllipseItem(){ return ellipse; }
+
+QGraphicsRectItem* GSimpleProcess::getMarginRect() { return this->marginRect; }
+
+
+bool GSimpleProcess::checkCollisions() {
+
+    QList<QGraphicsItem*> collidItems = marginRect->collidingItems();
+    foreach (QGraphicsItem *item, collidItems) {
+        // detect margins of GProcess items from other sorts
+        if (item->data(marginZone).toBool()) {
+            if (item->data(sortName).toString() != process->getSort()->getName().c_str()) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+ProcessPtr* GSimpleProcess::getProcess() { return &(this->process); }

--- a/src/gfx/GSimpleProcess.cpp~
+++ b/src/gfx/GSimpleProcess.cpp~
@@ -1,0 +1,83 @@
+#include <iostream>
+#include <QPen>
+#include <QColor>
+#include <QBrush>
+#include <QSizeF>
+#include <QTextDocument>
+#include <Qt>
+#include "GSimpleProcess.h"
+#include <math.h>
+
+
+const int GSimpleProcess::marginZone  = 10;
+const int GSimpleProcess::sortName    = 11;
+
+GSimpleProcess::GSimpleProcess(ProcessPtr p, double centerX, double centerY, double width, double height): process(p) {
+
+    display = new QGraphicsItemGroup();
+
+    // ellipse
+    ellipse = new QGraphicsEllipseItem (centerX, centerY,
+                                        width, height, display);
+	ellipse->setPen(QPen(QColor(238,232,213)));
+	ellipse->setBrush(QBrush(QColor(238,232,213)));
+
+/* 
+    //int margin( (int) ceil(GVSubGraph::sepValue * graphDPI / GVGraph::DotDefaultDPI) );
+    int margin = 30;
+    marginRect = new QGraphicsRectItem(
+                centerX -width/2 - margin,
+                centerY - height/2 - margin,
+                width + 2*margin,
+                height + 2*margin,
+                display);
+                
+    marginRect->setBrush(Qt::NoBrush);
+    marginRect->setPen(Qt::NoPen);
+    marginRect->setData(marginZone, true);
+    marginRect->setData(sortName, process->getSort()->getName().c_str());
+    
+    // text
+    text = new QGraphicsTextItem (QString("%1").arg(process->getNumber()), ellipse);
+    text->setDefaultTextColor(QColor(7,54,66));
+    text->setPos(centerX, centerY);
+
+    // position the text
+	QSizeF textSize = text->document()->size();
+	text->setPos(text->x() - textSize.width()/2, text->y() - textSize.height()/2);
+*/
+}
+
+
+GSimpleProcess::~GSimpleProcess() {
+    delete ellipse;
+    delete text;
+	delete display;
+}
+
+
+// getters
+
+QGraphicsItem* GSimpleProcess::getDisplayItem (void) { return display; }
+
+QGraphicsEllipseItem* GSimpleProcess::getEllipseItem(){ return ellipse; }
+
+QGraphicsRectItem* GSimpleProcess::getMarginRect() { return this->marginRect; }
+
+
+bool GSimpleProcess::checkCollisions() {
+
+    QList<QGraphicsItem*> collidItems = marginRect->collidingItems();
+    foreach (QGraphicsItem *item, collidItems) {
+        // detect margins of GProcess items from other sorts
+        if (item->data(marginZone).toBool()) {
+            if (item->data(sortName).toString() != process->getSort()->getName().c_str()) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+ProcessPtr* GProcess::getProcess() { return &(this->process); }

--- a/src/gfx/GSort.cpp
+++ b/src/gfx/GSort.cpp
@@ -45,7 +45,7 @@ GSort::GSort(SortPtr s, GVCluster c) :
 }
 
 GSort::GSort(SortPtr s, GVNode n) :
-    QGraphicsRectItem(n.centerPos.x()-n.width/2, n.centerPos.y()-n.height/2, n.width, n.height),
+    QGraphicsRectItem(n.centerPos.x()-n.width/2, n.centerPos.y()-n.height/2, n.width/4, n.height),
     sort(s), node(n) {
 
     // graphic items set and Actions color

--- a/src/gfx/GSort.cpp
+++ b/src/gfx/GSort.cpp
@@ -71,13 +71,24 @@ GSort::GSort(SortPtr s, GVNode n) : sort(s), node(n) {
     setCursor(QCursor(Qt::OpenHandCursor));
     setAcceptedMouseButtons(Qt::LeftButton | Qt::RightButton);
 
+    // set related GProcesses as children (so they move with this GSort)
+    vector<ProcessPtr> processes = sort->getProcesses();
+    int nbProcess = processes.size();
+    int currPosYProcess = heightRect/nbProcess;
+    for(ProcessPtr &p : processes){
+	gProcesses.push_back(make_shared<GProcess>(p, xCornerPos + widthRect/2, yCornerPos+ currPosYProcess, widthRect-10, heightRect/(nbProcess+1)-30));
+	currPosYProcess+=heightRect/(nbProcess+1);
+    }
+    for(GProcessPtr &gp: gProcesses){
+	gp->getDisplayItem()->setParentItem(this);
+    }
 }
 
 GSort::~GSort() {
+    gProcesses.clear();
     delete _rect;
-    delete text;
+    delete text;   
 }
-
 
 // mouse press event handler: start "drag"
 void GSort::mousePressEvent(QGraphicsSceneMouseEvent *event) {

--- a/src/gfx/GSort.cpp
+++ b/src/gfx/GSort.cpp
@@ -74,7 +74,7 @@ GSort::GSort(SortPtr s, GVNode n) : sort(s), node(n) {
     // set related GProcesses as children (so they move with this GSort)
     vector<ProcessPtr> processes = sort->getProcesses();
     int nbProcess = processes.size();
-    int currPosYProcess = heightRect/nbProcess;
+    int currPosYProcess = heightRect/(1.5*nbProcess);
     for(ProcessPtr &p : processes){
 	gProcesses.push_back(make_shared<GProcess>(p, xCornerPos + widthRect/2, yCornerPos+ currPosYProcess, widthRect-10, heightRect/(nbProcess+1)-30));
 	currPosYProcess+=heightRect/(nbProcess+1);
@@ -82,6 +82,7 @@ GSort::GSort(SortPtr s, GVNode n) : sort(s), node(n) {
     for(GProcessPtr &gp: gProcesses){
 	gp->getDisplayItem()->setParentItem(this);
     }
+
 }
 
 GSort::~GSort() {

--- a/src/gfx/GSort.cpp
+++ b/src/gfx/GSort.cpp
@@ -44,7 +44,7 @@ GSort::GSort(SortPtr s, GVCluster c) :
 
 }
 
-GSort::GSort(SortPtr s, GVNode n) : sort(s), node(n) {
+GSort::GSort(SortPtr s, GVNode n) : QGraphicsRectItem(n.centerPos.x()-n.width/8, n.centerPos.y()-n.height/2, n.width/4, n.height),sort(s), node(n) {
 
     // graphic items set and Actions color
     color = makeColor();
@@ -55,8 +55,7 @@ GSort::GSort(SortPtr s, GVNode n) : sort(s), node(n) {
     yCornerPos = n.centerPos.y()-heightRect/2;
 
     // rectangle
-    _rect = new QGraphicsRectItem(this);
-    _rect->setRect(QRectF(xCornerPos, yCornerPos, widthRect, heightRect));
+    _rect = new QGraphicsRectItem(QRectF(xCornerPos, yCornerPos, widthRect, heightRect),this);
     _rect->setPen(QPen(QColor(7,54,66)));
     _rect->setBrush(QBrush(QColor(7,54,66)));
 

--- a/src/gfx/GSort.cpp
+++ b/src/gfx/GSort.cpp
@@ -44,17 +44,32 @@ GSort::GSort(SortPtr s, GVCluster c) :
 
 }
 
-GSort::GSort(SortPtr s, GVNode n) :
-    QGraphicsRectItem(n.centerPos.x()-n.width/2, n.centerPos.y()-n.height/2, n.width/4, n.height),
-    sort(s), node(n) {
+GSort::GSort(SortPtr s, GVNode n) : sort(s), node(n) {
 
     // graphic items set and Actions color
     color = makeColor();
+    double widthRect, heightRect, xCornerPos, yCornerPos;
+    widthRect = n.width/4;
+    heightRect = n.height;
+    xCornerPos = n.centerPos.x()-widthRect/2;
+    yCornerPos = n.centerPos.y()-heightRect/2;
 
     // rectangle
-    _rect = new QGraphicsRectItem(boundingRect(), this);
+    _rect = new QGraphicsRectItem(this);
+    _rect->setRect(QRectF(xCornerPos, yCornerPos, widthRect, heightRect));
     _rect->setPen(QPen(QColor(7,54,66)));
     _rect->setBrush(QBrush(QColor(7,54,66)));
+
+    // label
+    text = new QGraphicsTextItem (QString(), this);
+    text->setHtml(QString::fromStdString("<u>sort " + sort->getName() + "</u>"));
+    text->setDefaultTextColor(*color);
+    text->setPos(xCornerPos+widthRect/2, yCornerPos);
+    QSizeF textSize = text->document()->size();
+    text->setPos(text->x() - textSize.width()/2, text->y());
+
+    setCursor(QCursor(Qt::OpenHandCursor));
+    setAcceptedMouseButtons(Qt::LeftButton | Qt::RightButton);
 
 }
 

--- a/src/gfx/GSort.cpp~
+++ b/src/gfx/GSort.cpp~
@@ -66,18 +66,29 @@ GSort::GSort(SortPtr s, GVNode n) : sort(s), node(n) {
     text->setDefaultTextColor(*color);
     text->setPos(xCornerPos+widthRect/2, yCornerPos);
     QSizeF textSize = text->document()->size();
-    text->setPos(text->x() - textSize.width()/2, text->y() + textSize.height()/2);
+    text->setPos(text->x() - textSize.width()/2, text->y());
 
     setCursor(QCursor(Qt::OpenHandCursor));
     setAcceptedMouseButtons(Qt::LeftButton | Qt::RightButton);
 
+    // set related GProcesses as children (so they move with this GSort)
+    vector<ProcessPtr> processes = sort->getProcesses();
+    int nbProcess = processes.size();
+    int currPosYProcess = heightRect/nbProcess;
+    for(ProcessPtr &p : processes){
+	gProcesses.push_back(make_shared<GProcess>(p, xCornerPos + widthRect/2, yCornerPos+ currPosYProcess, widthRect-10, heightRect/(nbProcess+1)-30));
+	currPosYProcess+=heightRect/(nbProcess+1);
+    }
+    for(GProcessPtr &gp: gProcesses){
+	gp->getDisplayItem()->setParentItem(this);
+    }
 }
 
 GSort::~GSort() {
+    gProcesses.clear();
     delete _rect;
-    delete text;
+    delete text;   
 }
-
 
 // mouse press event handler: start "drag"
 void GSort::mousePressEvent(QGraphicsSceneMouseEvent *event) {

--- a/src/gfx/GSort.cpp~
+++ b/src/gfx/GSort.cpp~
@@ -45,7 +45,7 @@ GSort::GSort(SortPtr s, GVCluster c) :
 }
 
 GSort::GSort(SortPtr s, GVNode n) :
-    QGraphicsRectItem(n.centerPos.x()-n.width/2, n.centerPos.y()-n.height/2, n.width, n.height),
+    QGraphicsRectItem(n.centerPos.x(), n.centerPos.y(), n.width, n.height),
     sort(s), node(n) {
 
     // graphic items set and Actions color

--- a/src/gfx/GSort.cpp~
+++ b/src/gfx/GSort.cpp~
@@ -45,7 +45,7 @@ GSort::GSort(SortPtr s, GVCluster c) :
 }
 
 GSort::GSort(SortPtr s, GVNode n) :
-    QGraphicsRectItem(n.centerPos.x(), n.centerPos.y(), n.width, n.height),
+    QGraphicsRectItem(n.centerPos.x()-n.width/2, n.centerPos.y()-n.height/2, n.width/2, n.height),
     sort(s), node(n) {
 
     // graphic items set and Actions color

--- a/src/gfx/GSort.cpp~
+++ b/src/gfx/GSort.cpp~
@@ -44,7 +44,7 @@ GSort::GSort(SortPtr s, GVCluster c) :
 
 }
 
-GSort::GSort(SortPtr s, GVNode n) : sort(s), node(n) {
+GSort::GSort(SortPtr s, GVNode n) : QGraphicsRectItem(n.centerPos.x()-n.width/8, yCornerPos, n.width/4, n.height),sort(s), node(n) {
 
     // graphic items set and Actions color
     color = makeColor();
@@ -55,8 +55,7 @@ GSort::GSort(SortPtr s, GVNode n) : sort(s), node(n) {
     yCornerPos = n.centerPos.y()-heightRect/2;
 
     // rectangle
-    _rect = new QGraphicsRectItem(this);
-    _rect->setRect(QRectF(xCornerPos, yCornerPos, widthRect, heightRect));
+    _rect = new QGraphicsRectItem(QRectF(xCornerPos, yCornerPos, widthRect, heightRect),this);
     _rect->setPen(QPen(QColor(7,54,66)));
     _rect->setBrush(QBrush(QColor(7,54,66)));
 
@@ -75,13 +74,13 @@ GSort::GSort(SortPtr s, GVNode n) : sort(s), node(n) {
     vector<ProcessPtr> processes = sort->getProcesses();
     int nbProcess = processes.size();
     int currPosYProcess = heightRect/(1.5*nbProcess);
-    /*for(ProcessPtr &p : processes){
+    for(ProcessPtr &p : processes){
 	gProcesses.push_back(make_shared<GProcess>(p, xCornerPos + widthRect/2, yCornerPos+ currPosYProcess, widthRect-10, heightRect/(nbProcess+1)-30));
 	currPosYProcess+=heightRect/(nbProcess+1);
     }
     for(GProcessPtr &gp: gProcesses){
 	gp->getDisplayItem()->setParentItem(this);
-    }*/
+    }
 
 }
 

--- a/src/gfx/GSort.cpp~
+++ b/src/gfx/GSort.cpp~
@@ -44,17 +44,32 @@ GSort::GSort(SortPtr s, GVCluster c) :
 
 }
 
-GSort::GSort(SortPtr s, GVNode n) :
-    QGraphicsRectItem(n.centerPos.x()-n.width/2, n.centerPos.y()-n.height/2, n.width/2, n.height),
-    sort(s), node(n) {
+GSort::GSort(SortPtr s, GVNode n) : sort(s), node(n) {
 
     // graphic items set and Actions color
     color = makeColor();
+    double widthRect, heightRect, xCornerPos, yCornerPos;
+    widthRect = n.width/4;
+    heightRect = n.height;
+    xCornerPos = n.centerPos.x()-widthRect/2;
+    yCornerPos = n.centerPos.y()-heightRect/2;
 
     // rectangle
-    _rect = new QGraphicsRectItem(boundingRect(), this);
+    _rect = new QGraphicsRectItem(this);
+    _rect->setRect(QRectF(xCornerPos, yCornerPos, widthRect, heightRect));
     _rect->setPen(QPen(QColor(7,54,66)));
     _rect->setBrush(QBrush(QColor(7,54,66)));
+
+    // label
+    text = new QGraphicsTextItem (QString(), this);
+    text->setHtml(QString::fromStdString("<u>sort " + sort->getName() + "</u>"));
+    text->setDefaultTextColor(*color);
+    text->setPos(xCornerPos+widthRect/2, yCornerPos);
+    QSizeF textSize = text->document()->size();
+    text->setPos(text->x() - textSize.width()/2, text->y() + textSize.height()/2);
+
+    setCursor(QCursor(Qt::OpenHandCursor));
+    setAcceptedMouseButtons(Qt::LeftButton | Qt::RightButton);
 
 }
 

--- a/src/gfx/GSort.cpp~
+++ b/src/gfx/GSort.cpp~
@@ -74,14 +74,15 @@ GSort::GSort(SortPtr s, GVNode n) : sort(s), node(n) {
     // set related GProcesses as children (so they move with this GSort)
     vector<ProcessPtr> processes = sort->getProcesses();
     int nbProcess = processes.size();
-    int currPosYProcess = heightRect/nbProcess;
-    for(ProcessPtr &p : processes){
+    int currPosYProcess = heightRect/(1.5*nbProcess);
+    /*for(ProcessPtr &p : processes){
 	gProcesses.push_back(make_shared<GProcess>(p, xCornerPos + widthRect/2, yCornerPos+ currPosYProcess, widthRect-10, heightRect/(nbProcess+1)-30));
 	currPosYProcess+=heightRect/(nbProcess+1);
     }
     for(GProcessPtr &gp: gProcesses){
 	gp->getDisplayItem()->setParentItem(this);
-    }
+    }*/
+
 }
 
 GSort::~GSort() {

--- a/src/gfx/PHScene.cpp
+++ b/src/gfx/PHScene.cpp
@@ -22,24 +22,19 @@ void PHScene::doRender(void) {
 
     // retrieve graph
 	GVGraphPtr graph = ph->toGVGraph();
-	ph->createSkeletonGraph();
 	
     // create GProcesses linking actual processes (PH info) with GVNodes (display info)
     QList<GVNode> gnodes = graph->nodes();
 	for (GVNode &gn : gnodes) {
-        for (SortPtr &s : ph->getSorts()) {
-            for (ProcessPtr &p : s->getProcesses()) {
-                if (gn.name == makeProcessName(p)) {
-                    GProcessPtr gp = make_shared<GProcess>(p, gn, graph->getDPI());
-                    processes.push_back(gp);
-                    p.get()->setGProcess(gp);
-                }
-               // else{
-
-                 //   throw process_not_found();
-                //}
-			}
-        }
+            for (SortPtr &s : ph->getSorts()) {
+            	for (ProcessPtr &p : s->getProcesses()) {
+            	    if (gn.name == makeProcessName(p)) {
+            	        GProcessPtr gp = make_shared<GProcess>(p, gn, graph->getDPI());
+            	        processes.push_back(gp);
+            	        p.get()->setGProcess(gp);
+            	    }
+	    	}
+            }
 	}
 	
     // create GSorts linking actual sorts (PH info) with GVClusters (display info)
@@ -55,6 +50,19 @@ void PHScene::doRender(void) {
     draw();
 }
 
+void PHScene::drawFromSkeleton(void){
+	GVSkeletonGraphPtr gSkeleton = ph->createSkeletonGraph();
+	
+	QList<GVNode> gSkeletonNodes = gSkeleton->nodes();
+	for(GVNode &gn : gSkeletonNodes){
+		for(SortPtr &s : ph->getSorts()){
+			if(gn.name == makeSkeletonNodeName(s->getName())){
+				sorts.insert(GSortEntry(s->getName(), make_shared<GSort>(s,gn)));			
+			}
+		}	
+	}
+    	draw();
+}
 
 // draw all the elements of the scene
 void PHScene::draw(void) {

--- a/src/gfx/PHScene.cpp
+++ b/src/gfx/PHScene.cpp
@@ -61,6 +61,7 @@ void PHScene::drawFromSkeleton(void){
 			}
 		}	
 	}
+	// Clear the scene and add sorts item (containing also processes) to the scene
 	clear();
     	for (auto &s : sorts){
         	addItem(s.second.get());

--- a/src/gfx/PHScene.cpp
+++ b/src/gfx/PHScene.cpp
@@ -61,7 +61,10 @@ void PHScene::drawFromSkeleton(void){
 			}
 		}	
 	}
-    	draw();
+	clear();
+    	for (auto &s : sorts){
+        	addItem(s.second.get());
+	}
 }
 
 // draw all the elements of the scene

--- a/src/gfx/PHScene.cpp~
+++ b/src/gfx/PHScene.cpp~
@@ -61,11 +61,11 @@ void PHScene::drawFromSkeleton(void){
 			}
 		}	
 	}
+	// Clear the scene and draw sorts
 	clear();
     	for (auto &s : sorts){
         	addItem(s.second.get());
 	}
-    	draw();
 }
 
 // draw all the elements of the scene

--- a/src/gfx/PHScene.cpp~
+++ b/src/gfx/PHScene.cpp~
@@ -26,19 +26,15 @@ void PHScene::doRender(void) {
     // create GProcesses linking actual processes (PH info) with GVNodes (display info)
     QList<GVNode> gnodes = graph->nodes();
 	for (GVNode &gn : gnodes) {
-        for (SortPtr &s : ph->getSorts()) {
-            for (ProcessPtr &p : s->getProcesses()) {
-                if (gn.name == makeProcessName(p)) {
-                    GProcessPtr gp = make_shared<GProcess>(p, gn, graph->getDPI());
-                    processes.push_back(gp);
-                    p.get()->setGProcess(gp);
-                }
-               // else{
-
-                 //   throw process_not_found();
-                //}
-			}
-        }
+            for (SortPtr &s : ph->getSorts()) {
+            	for (ProcessPtr &p : s->getProcesses()) {
+            	    if (gn.name == makeProcessName(p)) {
+            	        GProcessPtr gp = make_shared<GProcess>(p, gn, graph->getDPI());
+            	        processes.push_back(gp);
+            	        p.get()->setGProcess(gp);
+            	    }
+	    	}
+            }
 	}
 	
     // create GSorts linking actual sorts (PH info) with GVClusters (display info)
@@ -54,6 +50,18 @@ void PHScene::doRender(void) {
     draw();
 }
 
+void PHScene::drawFromSkeleton(void){
+	GVSkeletonGraphPtr gSkeleton = ph->createSkeletonGraph();
+	
+	QList<GVNode> gSkeletonNodes = gSkeleton->nodes();
+	for(GVNode &gn : gSkeletonNodes){
+		for(SortPtr &s : ph->getSorts()){
+			if(gn.name == makeSkeletonNodeName(s->getName())){
+				sorts.insert(GSortEntry(s->getName(), make_shared<GSort>(s,gn)));			
+			}
+		}	
+	}
+}
 
 // draw all the elements of the scene
 void PHScene::draw(void) {

--- a/src/gfx/PHScene.cpp~
+++ b/src/gfx/PHScene.cpp~
@@ -61,6 +61,11 @@ void PHScene::drawFromSkeleton(void){
 			}
 		}	
 	}
+	clear();
+    	for (auto &s : sorts){
+        	addItem(s.second.get());
+	}
+    	draw();
 }
 
 // draw all the elements of the scene

--- a/src/gviz/GVSkeletonGraph.cpp
+++ b/src/gviz/GVSkeletonGraph.cpp
@@ -7,8 +7,8 @@
 #include "GVSkeletonGraph.h"
 
 const qreal GVSkeletonGraph::DotDefaultDPI=72.0;
-const qreal GVSkeletonGraph::nodeSize = 50;
-const qreal GVSkeletonGraph::sepValue = 12.0;
+const qreal GVSkeletonGraph::nodeSize = 400;
+const qreal GVSkeletonGraph::sepValue = 2000.0;
 
 // Utils
 
@@ -72,7 +72,7 @@ void GVSkeletonGraph::setFont(QFont font){
 
 void GVSkeletonGraph::applyLayout(){
 	gvFreeLayout(_context, _graph);
-	_gvLayout(_context, _graph, "fdp");
+	_gvLayout(_context, _graph, "sfdp");
 }
 
 // Node management

--- a/src/gviz/GVSkeletonGraph.cpp~
+++ b/src/gviz/GVSkeletonGraph.cpp~
@@ -7,8 +7,10 @@
 #include "GVSkeletonGraph.h"
 
 const qreal GVSkeletonGraph::DotDefaultDPI=72.0;
-const qreal GVSkeletonGraph::nodeSize = 50;
-const qreal GVSkeletonGraph::sepValue = 12.0;
+const qreal GVSkeletonGraph::nodeSize = 100;
+const qreal GVSkeletonGraph::sepValue = 2000.0;
+
+// Utils
 
 static inline Agnode_t* _agnode(Agraph_t* object, QString name){
 	return agnode(object, const_cast<char *>(qPrintable(name)));
@@ -70,7 +72,7 @@ void GVSkeletonGraph::setFont(QFont font){
 
 void GVSkeletonGraph::applyLayout(){
 	gvFreeLayout(_context, _graph);
-	_gvLayout(_context, _graph, "fdp");
+	_gvLayout(_context, _graph, "sfdp");
 }
 
 // Node management

--- a/src/gviz/GVSkeletonGraph.cpp~
+++ b/src/gviz/GVSkeletonGraph.cpp~
@@ -7,7 +7,7 @@
 #include "GVSkeletonGraph.h"
 
 const qreal GVSkeletonGraph::DotDefaultDPI=72.0;
-const qreal GVSkeletonGraph::nodeSize = 100;
+const qreal GVSkeletonGraph::nodeSize = 400;
 const qreal GVSkeletonGraph::sepValue = 2000.0;
 
 // Utils

--- a/src/ph/PH.cpp
+++ b/src/ph/PH.cpp
@@ -30,7 +30,8 @@ PH::PH () {
 // trigger the rendering in the Scene
 void PH::render () {
     if (scene.use_count() == 0) scene = make_shared<PHScene>(this);
-    scene->doRender();
+    //scene->doRender();
+    scene->drawFromSkeleton();
 }
 
 // get graphics scene for display
@@ -129,7 +130,8 @@ GVSkeletonGraphPtr PH::createSkeletonGraph(void){
 			gSkeleton->addEdge(sourceName,targetName);
 		}
 	}
-	
+	gSkeleton->applyLayout();	
+
 	return gSkeleton;
 }
 

--- a/src/ph/PH.cpp
+++ b/src/ph/PH.cpp
@@ -105,9 +105,6 @@ GVGraphPtr PH::toGVGraph(void) {
             posVal = QString::number(0).append(",").append(QString::number(i)).append("!");
             _agset(res->getNode(makeProcessName(e.second->getProcess(i))), "pos", posVal);
         }
-        
-        vector<ProcessPtr> listProcess = e.second->getProcesses();
-        int nbProcess = listProcess.size();
     }
 	
     // let graphviz calculate an appropriate layout
@@ -118,9 +115,16 @@ GVGraphPtr PH::toGVGraph(void) {
 
 GVSkeletonGraphPtr PH::createSkeletonGraph(void){
 	GVSkeletonGraphPtr gSkeleton = make_shared<GVSkeletonGraph>(QString("Skeleton Graph"));
-	QString s;
+	QString sortName;
+        vector<ProcessPtr> listProcess;
+        QString nbProcess;
 	for(auto &e : sorts){
-		gSkeleton->addNode(makeSkeletonNodeName(e.second->getName()));
+		sortName = makeSkeletonNodeName(e.second->getName());
+		listProcess = e.second->getProcesses();
+		nbProcess = QString::number(listProcess.size());
+		gSkeleton->addNode(sortName);
+		gSkeleton->setGraphObjectAttributes(gSkeleton->getNode(sortName),"height",nbProcess);
+		gSkeleton->setGraphObjectAttributes(gSkeleton->getNode(sortName),"fixedsize","true");
 	}
 	
 	for (ActionPtr &a : actions){

--- a/src/ph/PH.cpp~
+++ b/src/ph/PH.cpp~
@@ -30,7 +30,8 @@ PH::PH () {
 // trigger the rendering in the Scene
 void PH::render () {
     if (scene.use_count() == 0) scene = make_shared<PHScene>(this);
-    scene->doRender();
+    //scene->doRender();
+    scene->drawFromSkeleton();
 }
 
 // get graphics scene for display
@@ -104,9 +105,6 @@ GVGraphPtr PH::toGVGraph(void) {
             posVal = QString::number(0).append(",").append(QString::number(i)).append("!");
             _agset(res->getNode(makeProcessName(e.second->getProcess(i))), "pos", posVal);
         }
-        
-        vector<ProcessPtr> listProcess = e.second->getProcesses();
-        int nbProcess = listProcess.size();
     }
 	
     // let graphviz calculate an appropriate layout
@@ -117,9 +115,16 @@ GVGraphPtr PH::toGVGraph(void) {
 
 GVSkeletonGraphPtr PH::createSkeletonGraph(void){
 	GVSkeletonGraphPtr gSkeleton = make_shared<GVSkeletonGraph>(QString("Skeleton Graph"));
-	QString s;
+	QString sortName;
+        vector<ProcessPtr> listProcess;
+        QString nbProcess;
 	for(auto &e : sorts){
-		gSkeleton->addNode(makeSkeletonNodeName(e.second->getName()));
+		sortName = makeSkeletonNodeName(e.second->getName());
+		listProcess = e.second->getProcesses();
+		nbProcess = QString::number(listProcess.size());
+		gSkeleton->addNode(sortName);
+		gSkeleton->setGraphObjectAttributes(gSkeleton->getNode(sortName),"height",nbProcess);
+		gSkeleton->setGraphObjectAttributes(gSkeleton->getNode(sortName),"fixedsize","true");
 	}
 	
 	for (ActionPtr &a : actions){
@@ -129,7 +134,7 @@ GVSkeletonGraphPtr PH::createSkeletonGraph(void){
 			gSkeleton->addEdge(sourceName,targetName);
 		}
 	}
-	gSkeleton->applyLayout();	
+	//gSkeleton->applyLayout();	
 
 	return gSkeleton;
 }

--- a/src/ph/PH.cpp~
+++ b/src/ph/PH.cpp~
@@ -122,8 +122,6 @@ GVSkeletonGraphPtr PH::createSkeletonGraph(void){
 		gSkeleton->addNode(makeSkeletonNodeName(e.second->getName()));
 	}
 	
-	QList<QPair<QString, QString>> linkSort;
-	
 	for (ActionPtr &a : actions){
 		QString sourceName = QString::fromStdString(a->getSource()->getSort()->getName());
 		QString targetName = QString::fromStdString(a->getTarget()->getSort()->getName());
@@ -131,11 +129,8 @@ GVSkeletonGraphPtr PH::createSkeletonGraph(void){
 			gSkeleton->addEdge(sourceName,targetName);
 		}
 	}
+	gSkeleton->applyLayout();	
 
-	for(QPair<QString, QString> pair : linkSort){
-		gSkeleton->addEdge(pair.first, pair.second);
-	}
-	
 	return gSkeleton;
 }
 


### PR DESCRIPTION
- One constructor added in GSort to create a GSort from a node of the skeleton graph
- The width of the rectangle created in GSort is 1/4 the width of the width of the node created in the skeleton graph (to have margin between nodes because I can't make it work through GraphViz)

TODO
- Need to adjust the width of the sort to make every part of the label inside the sort rectangle
