### PR TITLE
Empty methods created in PHScene and GAction to update actions in the scene

### DIFF
--- a/headers/GAction.h
+++ b/headers/GAction.h
@@ -57,6 +57,12 @@ class GAction {
 
         ~GAction();
 
+        /**
+          * @brief update position of GAction
+          *
+          */
+	void update();
+
      /**
        * @brief gets the display
        *

--- a/headers/GAction.h~
+++ b/headers/GAction.h~
@@ -110,7 +110,7 @@ class GAction {
           * @brief line representing the first part of the action
           *
           */
-	QGraphicsLineItemLine* hitLine;
+	QGraphicsLineItem* hitLine;
 
         /**
           * @brief the related Action

--- a/headers/PHScene.h
+++ b/headers/PHScene.h
@@ -99,6 +99,12 @@ class PHScene: public QGraphicsScene {
         void showActions();
 
         /**
+          * @brief update the position of actions
+          *
+          */
+	void updateAction();
+
+        /**
           * @brief recalculates the graph, functions of customized GSort items positions
           *
           */

--- a/headers/PHScene.h~
+++ b/headers/PHScene.h~
@@ -99,6 +99,12 @@ class PHScene: public QGraphicsScene {
         void showActions();
 
         /**
+          * @brief update the position of actions
+          *
+          */
+	void updateAction()
+
+        /**
           * @brief recalculates the graph, functions of customized GSort items positions
           *
           */
@@ -137,7 +143,7 @@ class PHScene: public QGraphicsScene {
           * @brief vector of the Processes drawn in the scene
           *
           */
-		std::vector<GProcessPtr> processes;
+	std::vector<GProcessPtr> processes;
 
         /**
           * @brief vector of the Actions drawn in the scene

--- a/src/gfx/GAction.cpp
+++ b/src/gfx/GAction.cpp
@@ -41,10 +41,15 @@ GAction::GAction(ActionPtr a, PHScene* sc) : scene(sc), action(a) {
     QSizeF* sizeSource = source->getSizeEllipse();
     QSizeF* sizeTarget = source->getSizeEllipse();
 
+/*
     QPointF* sourcePointLine = new QPointF(sizeSource->width()*hitVector->x()/2 + source->getCenterPoint()->x(),sizeSource->height()*hitVector->y()/2 + source->getCenterPoint()->y());
 
     QPointF* targetPointLine = new QPointF(-sizeTarget->width()*hitVector->x()/2 + target->getCenterPoint()->x(),-sizeTarget->height()*hitVector->y()/2 + target->getCenterPoint()->y());
+*/
 
+    QPointF* sourcePointLine = new QPointF(source->getCenterPoint()->x(),source->getCenterPoint()->y());
+
+    QPointF* targetPointLine = new QPointF(target->getCenterPoint()->x(),target->getCenterPoint()->y());
     hitLine = new QGraphicsLineItem(QLineF(*targetPointLine,*sourcePointLine),display);
     hitLine->setPen(QPen(QColor(0,0,0)));
 }
@@ -90,6 +95,8 @@ QGraphicsPolygonItem* GAction::makeArrowHead(const GVEdge& e, const QColor& colo
     return res;
 }
 
+void GAction::update(){
+}
 
 // getters
 

--- a/src/gfx/GAction.cpp~
+++ b/src/gfx/GAction.cpp~
@@ -38,13 +38,18 @@ GAction::GAction(ActionPtr a, PHScene* sc) : scene(sc), action(a) {
     QVector2D* hitVector = new QVector2D(*(target->getCenterPoint()) - *(source->getCenterPoint()));
     hitVector->normalize();
 
-    QSize* sizeSource = source->getSizeEllipse();
-    QSize* sizeTarget = source->getSizeEllipse();
+    QSizeF* sizeSource = source->getSizeEllipse();
+    QSizeF* sizeTarget = source->getSizeEllipse();
 
+/*
     QPointF* sourcePointLine = new QPointF(sizeSource->width()*hitVector->x()/2 + source->getCenterPoint()->x(),sizeSource->height()*hitVector->y()/2 + source->getCenterPoint()->y());
 
     QPointF* targetPointLine = new QPointF(-sizeTarget->width()*hitVector->x()/2 + target->getCenterPoint()->x(),-sizeTarget->height()*hitVector->y()/2 + target->getCenterPoint()->y());
+*/
 
+    QPointF* sourcePointLine = new QPointF(source->getCenterPoint()->x(),source->getCenterPoint()->y());
+
+    QPointF* targetPointLine = new QPointF(target->getCenterPoint()->x(),target->getCenterPoint()->y());
     hitLine = new QGraphicsLineItem(QLineF(*targetPointLine,*sourcePointLine),display);
     hitLine->setPen(QPen(QColor(0,0,0)));
 }
@@ -89,6 +94,7 @@ QGraphicsPolygonItem* GAction::makeArrowHead(const GVEdge& e, const QColor& colo
     res->setBrush(QBrush(color));
     return res;
 }
+
 
 
 // getters

--- a/src/gfx/PHScene.cpp
+++ b/src/gfx/PHScene.cpp
@@ -116,6 +116,10 @@ void PHScene::hideActions() {
     }
 }
 
+void PHScene::updateAction(){
+
+}
+
 
 void PHScene::showActions() {
 

--- a/src/gfx/PHScene.cpp~
+++ b/src/gfx/PHScene.cpp~
@@ -68,11 +68,11 @@ void PHScene::drawFromSkeleton(void){
 	}
 
         createActions();
-/*
+
 	for (auto &a : actions){
 		addItem(a->getDisplayItem());
 	}
-*/
+
 }
 
 // draw all the elements of the scene
@@ -114,6 +114,10 @@ void PHScene::hideActions() {
     for (GActionPtr &action : actions) {
         action->getDisplayItem()->hide();
     }
+}
+
+void PHScene::updateAction(){
+
 }
 
 


### PR DESCRIPTION
DONE
- Empty functions in PHScene and in GAction to update actions

TODO
- Fill these functions
- Use circle instead of ellipse to represent processes
- Make the two points of the first part of the action exactly on the border of the GProcess
