### PR TITLE
Modifications of size of GProcess and GSort

### DIFF
--- a/headers/GProcess.h
+++ b/headers/GProcess.h
@@ -29,6 +29,8 @@ class GProcess {
 
 	public:
 
+	static const int sizeDefault;
+
         /**
           * @brief constructor
           *
@@ -48,7 +50,7 @@ class GProcess {
           * @param double height height of the ellipse
 
           */
-	GProcess(ProcessPtr p,double centerX, double centerY, double width, double height);
+	GProcess(ProcessPtr p,double centerX, double centerY);
 
 		~GProcess();
 

--- a/headers/GProcess.h~
+++ b/headers/GProcess.h~
@@ -29,6 +29,8 @@ class GProcess {
 
 	public:
 
+	static const int sizeDefault;
+
         /**
           * @brief constructor
           *
@@ -149,13 +151,13 @@ class GProcess {
           * @brief position of the center of the ellipse representing the process
           *
           */
-	QPoint* center;
+	QPointF* center;
 
        /**
           * @brief size of the ellipse representing the process
           *
           */
-	QSize* size;
+	QSizeF* size;
 
         /**
           * @brief the graphical item representing the ellipse of the Process

--- a/headers/GSort.h
+++ b/headers/GSort.h
@@ -33,6 +33,8 @@ class GSort : public QGraphicsRectItem {
 
 	public:
 
+	static const int marginDefault;
+
         /** 
           * @brief constructor
           *
@@ -49,7 +51,7 @@ class GSort : public QGraphicsRectItem {
           * @param GVNode the node of the skeleton graph containing layout info
 
           */
-		GSort(SortPtr p, GVNode n);
+		GSort(SortPtr p, GVNode n, qreal width, qreal height);
 
 		~GSort();
 

--- a/headers/GSort.h~
+++ b/headers/GSort.h~
@@ -33,6 +33,8 @@ class GSort : public QGraphicsRectItem {
 
 	public:
 
+	static const int marginDefault;
+
         /** 
           * @brief constructor
           *
@@ -49,7 +51,7 @@ class GSort : public QGraphicsRectItem {
           * @param GVNode the node of the skeleton graph containing layout info
 
           */
-		GSort(SortPtr p, GVNode n);
+		GSort(SortPtr p, GVNode n, qreal width, qreal height);
 
 		~GSort();
 
@@ -165,7 +167,7 @@ class GSort : public QGraphicsRectItem {
           * @brief position of the left top corner of the rectangle representing the sort
           *
           */
-	QPoint leftTopCorner;
+	QPoint* leftTopCorner;
 
         /**
           * @brief size of the rectangle representing the sort

--- a/headers/GVSkeletonGraph.h
+++ b/headers/GVSkeletonGraph.h
@@ -118,6 +118,8 @@ class GVSkeletonGraph {
 		 */	
 		bool hasNode(const QString& name);
 
+		void setNodeSize(void* object, qreal width, qreal height);
+
 		/**
 		 * @brief gets a node by its name
 		 * @param QString name the name of the node to get

--- a/headers/GVSkeletonGraph.h~
+++ b/headers/GVSkeletonGraph.h~
@@ -118,6 +118,8 @@ class GVSkeletonGraph {
 		 */	
 		bool hasNode(const QString& name);
 
+		void setNodeSize(void* object, qreal width, qreal height);
+
 		/**
 		 * @brief gets a node by its name
 		 * @param QString name the name of the node to get

--- a/src/gfx/GAction.cpp
+++ b/src/gfx/GAction.cpp
@@ -41,15 +41,15 @@ GAction::GAction(ActionPtr a, PHScene* sc) : scene(sc), action(a) {
     QSizeF* sizeSource = source->getSizeEllipse();
     QSizeF* sizeTarget = source->getSizeEllipse();
 
-/*
+
     QPointF* sourcePointLine = new QPointF(sizeSource->width()*hitVector->x()/2 + source->getCenterPoint()->x(),sizeSource->height()*hitVector->y()/2 + source->getCenterPoint()->y());
 
     QPointF* targetPointLine = new QPointF(-sizeTarget->width()*hitVector->x()/2 + target->getCenterPoint()->x(),-sizeTarget->height()*hitVector->y()/2 + target->getCenterPoint()->y());
-*/
 
+/*
     QPointF* sourcePointLine = new QPointF(source->getCenterPoint()->x(),source->getCenterPoint()->y());
-
     QPointF* targetPointLine = new QPointF(target->getCenterPoint()->x(),target->getCenterPoint()->y());
+*/  
     hitLine = new QGraphicsLineItem(QLineF(*targetPointLine,*sourcePointLine),display);
     hitLine->setPen(QPen(QColor(0,0,0)));
 }

--- a/src/gfx/GAction.cpp~
+++ b/src/gfx/GAction.cpp~
@@ -95,7 +95,8 @@ QGraphicsPolygonItem* GAction::makeArrowHead(const GVEdge& e, const QColor& colo
     return res;
 }
 
-
+void GAction::update(){
+}
 
 // getters
 

--- a/src/gfx/GProcess.cpp
+++ b/src/gfx/GProcess.cpp
@@ -11,7 +11,7 @@
 
 const int GProcess::marginZone  = 10;
 const int GProcess::sortName    = 11;
-
+const int GProcess::sizeDefault = 100;
 
 GProcess::GProcess(ProcessPtr p, GVNode n, qreal graphDPI) : process(p), node(n) {
 
@@ -46,29 +46,29 @@ GProcess::GProcess(ProcessPtr p, GVNode n, qreal graphDPI) : process(p), node(n)
 	text->setPos(text->x() - textSize.width()/2, text->y() - textSize.height()/2);
 }
 
-GProcess::GProcess(ProcessPtr p,double centerX, double centerY, double width, double height) : process(p){
+GProcess::GProcess(ProcessPtr p,double centerX, double centerY) : process(p){
 
     display = new QGraphicsItemGroup();
 
 
     // init size of the ellipse and the position of the center
-    size = new QSizeF(width,height);
+    size = new QSizeF(sizeDefault,sizeDefault);
     center = new QPointF(centerX,centerY);
 
     // ellipse
-    ellipse = new QGraphicsEllipseItem (center->x()-size->width()/2, center->y()-size->height()/2,
+    ellipse = new QGraphicsEllipseItem (center->x()-sizeDefault/2, center->y()-sizeDefault/2,
                                         size->width(), size->height(), display);
 	ellipse->setPen(QPen(QColor(238,232,213)));
 	ellipse->setBrush(QBrush(QColor(238,232,213)));
 
 
-    //int margin( (int) ceil(GVSubGraph::sepValue * graphDPI / GVGraph::DotDefaultDPI) );
-    int margin = 30;
+    int margin(GSort::marginDefault);
+
     marginRect = new QGraphicsRectItem(
-                centerX - margin,
-                centerY - margin,
-                width + 2*margin,
-                height + 2*margin,
+                centerX - margin/2,
+                centerY - margin/2,
+                2*margin,
+                2*margin,
                 display);
                 
     marginRect->setBrush(Qt::NoBrush);

--- a/src/gfx/GProcess.cpp~
+++ b/src/gfx/GProcess.cpp~
@@ -11,7 +11,7 @@
 
 const int GProcess::marginZone  = 10;
 const int GProcess::sortName    = 11;
-
+const int GProcess::sizeDefault = 100;
 
 GProcess::GProcess(ProcessPtr p, GVNode n, qreal graphDPI) : process(p), node(n) {
 
@@ -46,29 +46,29 @@ GProcess::GProcess(ProcessPtr p, GVNode n, qreal graphDPI) : process(p), node(n)
 	text->setPos(text->x() - textSize.width()/2, text->y() - textSize.height()/2);
 }
 
-GProcess::GProcess(ProcessPtr p,double centerX, double centerY, double width, double height) : process(p){
+GProcess::GProcess(ProcessPtr p,double centerX, double centerY) : process(p){
 
     display = new QGraphicsItemGroup();
 
 
     // init size of the ellipse and the position of the center
-    size = new QSize(width,height);
-    center = new QPoint(centerX,centerY);
+    size = new QSizeF(sizeDefault,sizeDefault);
+    center = new QPointF(centerX,centerY);
 
     // ellipse
-    ellipse = new QGraphicsEllipseItem (center->x()-size->width()/2, center->y()-size->height()/2,
+    ellipse = new QGraphicsEllipseItem (center->x()-sizeDefault/2, center->y()-sizeDefault/2,
                                         size->width(), size->height(), display);
 	ellipse->setPen(QPen(QColor(238,232,213)));
 	ellipse->setBrush(QBrush(QColor(238,232,213)));
 
 
-    //int margin( (int) ceil(GVSubGraph::sepValue * graphDPI / GVGraph::DotDefaultDPI) );
-    int margin = 30;
+    int margin(GSort::marginDefault);
+
     marginRect = new QGraphicsRectItem(
-                centerX - margin,
-                centerY - margin,
-                width + 2*margin,
-                height + 2*margin,
+                centerX - margin/2,
+                centerY - margin/2,
+                margin,
+                margin,
                 display);
                 
     marginRect->setBrush(Qt::NoBrush);

--- a/src/gfx/GSort.cpp
+++ b/src/gfx/GSort.cpp
@@ -14,6 +14,8 @@
 #include "GSort.h"
 #include "Process.h"
 
+const int GSort::marginDefault = 10;
+
 GSort::GSort(SortPtr s, GVCluster c) :
     QGraphicsRectItem(c.topLeft.x(), c.topLeft.y(), c.width, c.height),
     sort(s), cluster(c) {
@@ -39,6 +41,7 @@ GSort::GSort(SortPtr s, GVCluster c) :
 
     // set related GProcesses as children (so they move with this GSort)
     vector<ProcessPtr> processes = sort->getProcesses();
+    
     for (ProcessPtr &process : processes) {
         process->getGProcess()->getDisplayItem()->setParentItem(this);
     }
@@ -46,12 +49,12 @@ GSort::GSort(SortPtr s, GVCluster c) :
 
 }
 
-GSort::GSort(SortPtr s, GVNode n) : QGraphicsRectItem(n.centerPos.x()-n.width/8, n.centerPos.y()-n.height/2, n.width/4, n.height),sort(s), node(n) {
+GSort::GSort(SortPtr s, GVNode n, qreal width, qreal height) : QGraphicsRectItem(n.centerPos.x()-width/2, n.centerPos.y()-height/2, width, height),sort(s), node(n) {
 
     // graphic items set and Actions color
     color = makeColor();
-    sizeRect = new QSize(n.width/4, n.height);
-    sizeRect->width();
+    sizeRect = new QSize(width, height);
+
     leftTopCorner = new QPoint(n.centerPos.x()-sizeRect->width()/2,n.centerPos.y()-sizeRect->height()/2);
 
     // rectangle
@@ -65,7 +68,7 @@ GSort::GSort(SortPtr s, GVNode n) : QGraphicsRectItem(n.centerPos.x()-n.width/8,
     text->setDefaultTextColor(*color);
     text->setPos(leftTopCorner->x()+sizeRect->width()/2, leftTopCorner->y());
     QSizeF textSize = text->document()->size();
-    text->setPos(text->x() - textSize.width()/2, text->y());
+    text->setPos(text->x() - textSize.width()/2, text->y() - textSize.height());
 
     setCursor(QCursor(Qt::OpenHandCursor));
     setAcceptedMouseButtons(Qt::LeftButton | Qt::RightButton);
@@ -73,16 +76,18 @@ GSort::GSort(SortPtr s, GVNode n) : QGraphicsRectItem(n.centerPos.x()-n.width/8,
     // set related GProcesses as children (so they move with this GSort)
     vector<ProcessPtr> processes = sort->getProcesses();
     int nbProcess = processes.size();
-    int currPosYProcess = sizeRect->height()/(1.5*nbProcess);
+    int currPosYProcess = marginDefault+GProcess::sizeDefault/2;
+
     for(ProcessPtr &p : processes){
-	gProcesses.push_back(make_shared<GProcess>(p, leftTopCorner->x() + sizeRect->width()/2, leftTopCorner->y()+ currPosYProcess, sizeRect->width()-10, sizeRect->height()/(nbProcess+1)-30));
-	currPosYProcess+=sizeRect->height()/(nbProcess+1);
+	gProcesses.push_back(make_shared<GProcess>(p, leftTopCorner->x() + GProcess::sizeDefault/2+ marginDefault, leftTopCorner->y()+ currPosYProcess));
+	currPosYProcess+= 2*marginDefault + GProcess::sizeDefault;
     }
     for(GProcessPtr &gp: gProcesses){
 	gp->getDisplayItem()->setParentItem(this);
 	ProcessPtr* p = gp->getProcess();
 	(*p)->setGProcess(gp);
     }
+
 }
 
 GSort::~GSort() {

--- a/src/gfx/GSort.cpp~
+++ b/src/gfx/GSort.cpp~
@@ -14,6 +14,8 @@
 #include "GSort.h"
 #include "Process.h"
 
+const int GSort::marginDefault = 10;
+
 GSort::GSort(SortPtr s, GVCluster c) :
     QGraphicsRectItem(c.topLeft.x(), c.topLeft.y(), c.width, c.height),
     sort(s), cluster(c) {
@@ -39,6 +41,7 @@ GSort::GSort(SortPtr s, GVCluster c) :
 
     // set related GProcesses as children (so they move with this GSort)
     vector<ProcessPtr> processes = sort->getProcesses();
+    
     for (ProcessPtr &process : processes) {
         process->getGProcess()->getDisplayItem()->setParentItem(this);
     }
@@ -46,12 +49,12 @@ GSort::GSort(SortPtr s, GVCluster c) :
 
 }
 
-GSort::GSort(SortPtr s, GVNode n) : QGraphicsRectItem(n.centerPos.x()-n.width/8, n.centerPos.y()-n.height/2, n.width/4, n.height),sort(s), node(n) {
+GSort::GSort(SortPtr s, GVNode n, qreal width, qreal height) : QGraphicsRectItem(n.centerPos.x()-width/2, n.centerPos.y()-height/2, width, height),sort(s), node(n) {
 
     // graphic items set and Actions color
     color = makeColor();
-    sizeRect = new QSize(n.width/4, n.height);
-    sizeRect->width();
+    sizeRect = new QSize(width, height);
+
     leftTopCorner = new QPoint(n.centerPos.x()-sizeRect->width()/2,n.centerPos.y()-sizeRect->height()/2);
 
     // rectangle
@@ -65,7 +68,7 @@ GSort::GSort(SortPtr s, GVNode n) : QGraphicsRectItem(n.centerPos.x()-n.width/8,
     text->setDefaultTextColor(*color);
     text->setPos(leftTopCorner->x()+sizeRect->width()/2, leftTopCorner->y());
     QSizeF textSize = text->document()->size();
-    text->setPos(text->x() - textSize.width()/2, text->y());
+    text->setPos(text->x() - textSize.width()/2, text->y() - textSize.height());
 
     setCursor(QCursor(Qt::OpenHandCursor));
     setAcceptedMouseButtons(Qt::LeftButton | Qt::RightButton);
@@ -73,16 +76,18 @@ GSort::GSort(SortPtr s, GVNode n) : QGraphicsRectItem(n.centerPos.x()-n.width/8,
     // set related GProcesses as children (so they move with this GSort)
     vector<ProcessPtr> processes = sort->getProcesses();
     int nbProcess = processes.size();
-    int currPosYProcess = sizeRect->height()/(1.5*nbProcess);
+    int currPosYProcess = marginDefault+GProcess::sizeDefault/2;
+
     for(ProcessPtr &p : processes){
-	gProcesses.push_back(make_shared<GProcess>(p, leftTopCorner->x() + sizeRect->width()/2, leftTopCorner->y()+ currPosYProcess, sizeRect->width()-10, sizeRect->height()/(nbProcess+1)-30));
-	currPosYProcess+=sizeRect->height()/(nbProcess+1);
+	gProcesses.push_back(make_shared<GProcess>(p, leftTopCorner->x() + GProcess::sizeDefault/2+ marginDefault, leftTopCorner->y()+ currPosYProcess));
+	currPosYProcess+= 2*marginDefault + GProcess::sizeDefault;
     }
     for(GProcessPtr &gp: gProcesses){
 	gp->getDisplayItem()->setParentItem(this);
 	ProcessPtr* p = gp->getProcess();
-	(*p)->getNumber();
+	(*p)->setGProcess(gp);
     }
+
 }
 
 GSort::~GSort() {

--- a/src/gfx/PHScene.cpp
+++ b/src/gfx/PHScene.cpp
@@ -56,8 +56,11 @@ void PHScene::drawFromSkeleton(void){
 	QList<GVNode> gSkeletonNodes = gSkeleton->nodes();
 	for(GVNode &gn : gSkeletonNodes){
 		for(SortPtr &s : ph->getSorts()){
+			int nbProcess = (s->getProcesses()).size();
+			int width = GProcess::sizeDefault+2*GSort::marginDefault;
+			int height = nbProcess*(GProcess::sizeDefault+2*GSort::marginDefault);
 			if(gn.name == makeSkeletonNodeName(s->getName())){
-				sorts.insert(GSortEntry(s->getName(), make_shared<GSort>(s,gn)));			
+				sorts.insert(GSortEntry(s->getName(), make_shared<GSort>(s,gn,width,height)));			
 			}
 		}	
 	}
@@ -72,7 +75,6 @@ void PHScene::drawFromSkeleton(void){
 	for (auto &a : actions){
 		addItem(a->getDisplayItem());
 	}
-
 }
 
 // draw all the elements of the scene

--- a/src/gfx/PHScene.cpp~
+++ b/src/gfx/PHScene.cpp~
@@ -56,8 +56,11 @@ void PHScene::drawFromSkeleton(void){
 	QList<GVNode> gSkeletonNodes = gSkeleton->nodes();
 	for(GVNode &gn : gSkeletonNodes){
 		for(SortPtr &s : ph->getSorts()){
+			int nbProcess = s->getProcesses()->size();
+			int width = GProcess::sizeDefault+2*GSort::marginDefault;
+			int height = nbProcess*(GProcess::sizeDefault+2*GSort::marginDefault);
 			if(gn.name == makeSkeletonNodeName(s->getName())){
-				sorts.insert(GSortEntry(s->getName(), make_shared<GSort>(s,gn)));			
+				sorts.insert(GSortEntry(s->getName(), make_shared<GSort>(s,gn,width,height)));			
 			}
 		}	
 	}
@@ -72,7 +75,6 @@ void PHScene::drawFromSkeleton(void){
 	for (auto &a : actions){
 		addItem(a->getDisplayItem());
 	}
-
 }
 
 // draw all the elements of the scene

--- a/src/gviz/GVSkeletonGraph.cpp
+++ b/src/gviz/GVSkeletonGraph.cpp
@@ -7,8 +7,8 @@
 #include "GVSkeletonGraph.h"
 
 const qreal GVSkeletonGraph::DotDefaultDPI=72.0;
-const qreal GVSkeletonGraph::nodeSize = 400;
-const qreal GVSkeletonGraph::sepValue = 2000.0;
+const qreal GVSkeletonGraph::nodeSize = 1;
+const qreal GVSkeletonGraph::sepValue = 30.0;
 
 // Utils
 
@@ -56,9 +56,6 @@ void GVSkeletonGraph::setGraphAttributes(){
 	setGraphObjectAttributes(_graph,"dpi","96,0");
 	QString strSepValue = QString::number(sepValue).prepend("+");
 	setGraphObjectAttributes(_graph, "sep", strSepValue);
-	
-	QString nodePtsWidth = QString("%1").arg(GVSkeletonGraph::nodeSize/_agget(_graph,"dpi", "96,0").replace(',',".").toDouble());
-	_agnodeattr(_graph, "width", nodePtsWidth.replace('.',","));
 }
 
 void GVSkeletonGraph::setGraphObjectAttributes(void *object, QString attr, QString value){
@@ -124,6 +121,13 @@ bool GVSkeletonGraph::hasNode(const QString& name){
 Agnode_t* GVSkeletonGraph::getNode(const QString& name){
 	if(_nodes.contains(name)) return _nodes[name];
 	return NULL;
+}
+
+void GVSkeletonGraph::setNodeSize(void* object, qreal width, qreal height){
+	QString nodePtsWidth = QString("%1").arg(width/_agget(_graph,"dpi", "96,0").replace(',',".").toDouble());
+	setGraphObjectAttributes(object,"width",nodePtsWidth.replace('.',","));
+	QString nodePtsHeight = QString("%1").arg(height/_agget(_graph,"dpi", "96,0").replace(',',".").toDouble());
+	setGraphObjectAttributes(object,"height",nodePtsHeight.replace('.',","));
 }
 
 void GVSkeletonGraph::clearNodes(){

--- a/src/gviz/GVSkeletonGraph.cpp~
+++ b/src/gviz/GVSkeletonGraph.cpp~
@@ -7,8 +7,8 @@
 #include "GVSkeletonGraph.h"
 
 const qreal GVSkeletonGraph::DotDefaultDPI=72.0;
-const qreal GVSkeletonGraph::nodeSize = 400;
-const qreal GVSkeletonGraph::sepValue = 2000.0;
+const qreal GVSkeletonGraph::nodeSize = 1;
+const qreal GVSkeletonGraph::sepValue = 20.0;
 
 // Utils
 
@@ -56,9 +56,6 @@ void GVSkeletonGraph::setGraphAttributes(){
 	setGraphObjectAttributes(_graph,"dpi","96,0");
 	QString strSepValue = QString::number(sepValue).prepend("+");
 	setGraphObjectAttributes(_graph, "sep", strSepValue);
-	
-	QString nodePtsWidth = QString("%1").arg(GVSkeletonGraph::nodeSize/_agget(_graph,"dpi", "96,0").replace(',',".").toDouble());
-	_agnodeattr(_graph, "width", nodePtsWidth.replace('.',","));
 }
 
 void GVSkeletonGraph::setGraphObjectAttributes(void *object, QString attr, QString value){
@@ -73,6 +70,11 @@ void GVSkeletonGraph::setFont(QFont font){
 void GVSkeletonGraph::applyLayout(){
 	gvFreeLayout(_context, _graph);
 	_gvLayout(_context, _graph, "dot");
+}
+
+
+void GVSkeletonGraph::exportToPng() {
+	gvRenderFilename(_context,_graph,"png","out.png");
 }
 
 // Node management
@@ -121,6 +123,13 @@ Agnode_t* GVSkeletonGraph::getNode(const QString& name){
 	return NULL;
 }
 
+void GVSkeletonGraph::setNodeSize(void* object, qreal width, qreal height){
+	QString nodePtsWidth = QString("%1").arg(width/_agget(_graph,"dpi", "96,0").replace(',',".").toDouble());
+	setGraphObjectAttributes(object,"width",nodePtsWidth.replace('.',","));
+	QString nodePtsHeight = QString("%1").arg(height/_agget(_graph,"dpi", "96,0").replace(',',".").toDouble());
+	setGraphObjectAttributes(object,"height",nodePtsHeight.replace('.',","));
+}
+
 void GVSkeletonGraph::clearNodes(){
 	QList<QString> keys = _nodes.keys();
 	for(int i=0;i<keys.size();++i){
@@ -161,6 +170,3 @@ qreal GVSkeletonGraph::getDPI(){
 
 Agraph_t* GVSkeletonGraph::graph() {return this->_graph;}
 
-void GVSkeletonGraph::exportToPng() {
-	gvRenderFilename(_context,_graph,"png","out.png");
-}

--- a/src/ph/PH.cpp
+++ b/src/ph/PH.cpp
@@ -117,13 +117,15 @@ GVSkeletonGraphPtr PH::createSkeletonGraph(void){
 	GVSkeletonGraphPtr gSkeleton = make_shared<GVSkeletonGraph>(QString("Skeleton Graph"));
 	QString sortName;
         vector<ProcessPtr> listProcess;
-        QString nbProcess;
+        int nbProcess;
 	for(auto &e : sorts){
 		sortName = makeSkeletonNodeName(e.second->getName());
 		listProcess = e.second->getProcesses();
-		nbProcess = QString::number(listProcess.size());
+		nbProcess = listProcess.size();
+		int width = GProcess::sizeDefault+2*GSort::marginDefault;
+		int height = nbProcess*(GProcess::sizeDefault+2*GSort::marginDefault);
 		gSkeleton->addNode(sortName);
-		gSkeleton->setGraphObjectAttributes(gSkeleton->getNode(sortName),"height",nbProcess);
+		gSkeleton->setNodeSize(gSkeleton->getNode(sortName),width,height);
 		gSkeleton->setGraphObjectAttributes(gSkeleton->getNode(sortName),"fixedsize","true");
 	}
 	
@@ -135,6 +137,7 @@ GVSkeletonGraphPtr PH::createSkeletonGraph(void){
 		}
 	}
 	gSkeleton->applyLayout();
+
 
 	return gSkeleton;
 }

--- a/src/ph/PH.cpp~
+++ b/src/ph/PH.cpp~
@@ -117,13 +117,15 @@ GVSkeletonGraphPtr PH::createSkeletonGraph(void){
 	GVSkeletonGraphPtr gSkeleton = make_shared<GVSkeletonGraph>(QString("Skeleton Graph"));
 	QString sortName;
         vector<ProcessPtr> listProcess;
-        QString nbProcess;
+        int nbProcess;
 	for(auto &e : sorts){
 		sortName = makeSkeletonNodeName(e.second->getName());
 		listProcess = e.second->getProcesses();
-		nbProcess = QString::number(listProcess.size());
+		nbProcess = listProcess.size();
+		int width = GProcess::sizeDefault+3*GSort::marginDefault;
+		int height = nbProcess*(GProcess::sizeDefault+3*GSort::marginDefault);
 		gSkeleton->addNode(sortName);
-		gSkeleton->setGraphObjectAttributes(gSkeleton->getNode(sortName),"height",nbProcess);
+		gSkeleton->setNodeSize(gSkeleton->getNode(sortName),width,height);
 		gSkeleton->setGraphObjectAttributes(gSkeleton->getNode(sortName),"fixedsize","true");
 	}
 	
@@ -136,7 +138,6 @@ GVSkeletonGraphPtr PH::createSkeletonGraph(void){
 	}
 	gSkeleton->applyLayout();
 
-        gSkeleton->exportToPng();
 
 	return gSkeleton;
 }


### PR DESCRIPTION
DONE
- Size of GVSkeletonNode and GSort calculated from GProcess::sizeDefault and GSort::marginDefault
- First part of actions drawn between border of two processes

TODO
- Clean the code
- Draw the second part of the action
- Increase separation between nodes of GVSkeletonGraph
- Deal with two sorts overlapping when moving one sort
