### PR TITLE
Draw-actions

### DIFF
--- a/headers/GAction.h
+++ b/headers/GAction.h
@@ -57,6 +57,12 @@ class GAction {
 
         ~GAction();
 
+        /**
+          * @brief update position of GAction
+          *
+          */
+	void update();
+
      /**
        * @brief gets the display
        *

--- a/headers/GAction.h
+++ b/headers/GAction.h
@@ -53,6 +53,8 @@ class GAction {
       */
 	GAction(ActionPtr a, PHScene* sc);
 
+	GAction();
+
         ~GAction();
 
      /**
@@ -108,7 +110,7 @@ class GAction {
           * @brief line representing the first part of the action
           *
           */
-	QLine* hitLine;
+	QGraphicsLineItem* hitLine;
 
         /**
           * @brief the related Action

--- a/headers/GAction.h~
+++ b/headers/GAction.h~
@@ -51,7 +51,7 @@ class GAction {
       * @param ActionPtr the related Action object
       * @param PHScene the related scene
       */
-	GAction(ActionPtr a, PHScene* sc);
+	GAction(ActionPtr a, PHScene* sc)
 
         ~GAction();
 

--- a/headers/GAction.h~
+++ b/headers/GAction.h~
@@ -110,7 +110,7 @@ class GAction {
           * @brief line representing the first part of the action
           *
           */
-	QGraphicsLineItemLine* hitLine;
+	QGraphicsLineItem* hitLine;
 
         /**
           * @brief the related Action

--- a/headers/GAction.h~
+++ b/headers/GAction.h~
@@ -51,7 +51,9 @@ class GAction {
       * @param ActionPtr the related Action object
       * @param PHScene the related scene
       */
-	GAction(ActionPtr a, PHScene* sc)
+	GAction(ActionPtr a, PHScene* sc);
+
+	GAction();
 
         ~GAction();
 
@@ -108,7 +110,7 @@ class GAction {
           * @brief line representing the first part of the action
           *
           */
-	QLine* hitLine;
+	QGraphicsLineItemLine* hitLine;
 
         /**
           * @brief the related Action

--- a/headers/GProcess.h
+++ b/headers/GProcess.h
@@ -29,6 +29,8 @@ class GProcess {
 
 	public:
 
+	static const int sizeDefault;
+
         /**
           * @brief constructor
           *
@@ -48,7 +50,7 @@ class GProcess {
           * @param double height height of the ellipse
 
           */
-	GProcess(ProcessPtr p,double centerX, double centerY, double width, double height);
+	GProcess(ProcessPtr p,double centerX, double centerY);
 
 		~GProcess();
 

--- a/headers/GProcess.h
+++ b/headers/GProcess.h
@@ -105,6 +105,22 @@ class GProcess {
         void setNode(GVNode gvnode);
 
         /**
+          * @brief get the center of the ellipse representing the process
+          *
+          * @return GPoint the center of the ellipse
+          *
+          */
+	QPoint* getCenterPoint();
+
+        /**
+          * @brief get the size of the ellipse representing the process
+          *
+          * @return GSize the size of the ellipse
+          *
+          */
+	QSize* getSizeEllipse();
+
+        /**
           * @brief checks collisions with margins of other GProcess items (see graph attribute "sep" in GVSubGraph)
           *
           * @return bool true if this GProcess' margin collides with another one's margin (of a different sort), else false
@@ -128,6 +144,18 @@ class GProcess {
           *
           */
 		QGraphicsItem* display;
+
+       /**
+          * @brief position of the center of the ellipse representing the process
+          *
+          */
+	QPoint* center;
+
+       /**
+          * @brief size of the ellipse representing the process
+          *
+          */
+	QSize* size;
 
         /**
           * @brief the graphical item representing the ellipse of the Process

--- a/headers/GProcess.h
+++ b/headers/GProcess.h
@@ -110,7 +110,7 @@ class GProcess {
           * @return GPoint the center of the ellipse
           *
           */
-	QPoint* getCenterPoint();
+	QPointF* getCenterPoint();
 
         /**
           * @brief get the size of the ellipse representing the process
@@ -118,7 +118,7 @@ class GProcess {
           * @return GSize the size of the ellipse
           *
           */
-	QSize* getSizeEllipse();
+	QSizeF* getSizeEllipse();
 
         /**
           * @brief checks collisions with margins of other GProcess items (see graph attribute "sep" in GVSubGraph)
@@ -149,13 +149,13 @@ class GProcess {
           * @brief position of the center of the ellipse representing the process
           *
           */
-	QPoint* center;
+	QPointF* center;
 
        /**
           * @brief size of the ellipse representing the process
           *
           */
-	QSize* size;
+	QSizeF* size;
 
         /**
           * @brief the graphical item representing the ellipse of the Process

--- a/headers/GProcess.h~
+++ b/headers/GProcess.h~
@@ -110,7 +110,7 @@ class GProcess {
           * @return GPoint the center of the ellipse
           *
           */
-	QPoint* getCenterPoint();
+	QPointF* getCenterPoint();
 
         /**
           * @brief get the size of the ellipse representing the process
@@ -118,7 +118,7 @@ class GProcess {
           * @return GSize the size of the ellipse
           *
           */
-	QSize getSizeEllipse();
+	QSizeF* getSizeEllipse();
 
         /**
           * @brief checks collisions with margins of other GProcess items (see graph attribute "sep" in GVSubGraph)

--- a/headers/GProcess.h~
+++ b/headers/GProcess.h~
@@ -29,6 +29,8 @@ class GProcess {
 
 	public:
 
+	static const int sizeDefault;
+
         /**
           * @brief constructor
           *
@@ -149,13 +151,13 @@ class GProcess {
           * @brief position of the center of the ellipse representing the process
           *
           */
-	QPoint* center;
+	QPointF* center;
 
        /**
           * @brief size of the ellipse representing the process
           *
           */
-	QSize* size;
+	QSizeF* size;
 
         /**
           * @brief the graphical item representing the ellipse of the Process

--- a/headers/GProcess.h~
+++ b/headers/GProcess.h~
@@ -10,7 +10,7 @@
 /**
   * @file GProcess.h
   * @brief header for the GProcess class
-  * @author PAPPL_2014
+  * @author PAPPL_2013
   *
   */
 
@@ -105,6 +105,22 @@ class GProcess {
         void setNode(GVNode gvnode);
 
         /**
+          * @brief get the center of the ellipse representing the process
+          *
+          * @return GPoint the center of the ellipse
+          *
+          */
+	QPoint* getCenterPoint();
+
+        /**
+          * @brief get the size of the ellipse representing the process
+          *
+          * @return GSize the size of the ellipse
+          *
+          */
+	QSize getSizeEllipse();
+
+        /**
           * @brief checks collisions with margins of other GProcess items (see graph attribute "sep" in GVSubGraph)
           *
           * @return bool true if this GProcess' margin collides with another one's margin (of a different sort), else false
@@ -128,6 +144,18 @@ class GProcess {
           *
           */
 		QGraphicsItem* display;
+
+       /**
+          * @brief position of the center of the ellipse representing the process
+          *
+          */
+	QPoint* center;
+
+       /**
+          * @brief size of the ellipse representing the process
+          *
+          */
+	QSize* size;
 
         /**
           * @brief the graphical item representing the ellipse of the Process

--- a/headers/GSort.h
+++ b/headers/GSort.h
@@ -33,6 +33,8 @@ class GSort : public QGraphicsRectItem {
 
 	public:
 
+	static const int marginDefault;
+
         /** 
           * @brief constructor
           *
@@ -49,7 +51,7 @@ class GSort : public QGraphicsRectItem {
           * @param GVNode the node of the skeleton graph containing layout info
 
           */
-		GSort(SortPtr p, GVNode n);
+		GSort(SortPtr p, GVNode n, qreal width, qreal height);
 
 		~GSort();
 

--- a/headers/GSort.h
+++ b/headers/GSort.h
@@ -2,6 +2,8 @@
 #include <QGraphicsRectItem>
 #include <QGraphicsTextItem>
 #include <QColor>
+#include <QSize>
+#include <QPoint>
 #include <vector>
 #include "PH.h"
 #include "Sort.h"
@@ -139,9 +141,37 @@ class GSort : public QGraphicsRectItem {
           */
         QPoint geteventPressPoint();
 
+        /**
+          * @brief get the center of the ellipse representing the process
+          *
+          * @return GPoint the center of the ellipse
+          *
+          */
+	QPoint* getLeftTopCornerPoint();
+
+        /**
+          * @brief get the size of the ellipse representing the process
+          *
+          * @return GSize the size of the ellipse
+          *
+          */
+	QSize* getSizeRect();
+
 
 		
 	protected:
+
+        /**
+          * @brief position of the left top corner of the rectangle representing the sort
+          *
+          */
+	QPoint* leftTopCorner;
+
+        /**
+          * @brief size of the rectangle representing the sort
+          *
+          */
+	QSize* sizeRect;
 
         /**
           * @brief the graphical item representing the rectangle of the Sort

--- a/headers/GSort.h~
+++ b/headers/GSort.h~
@@ -33,6 +33,8 @@ class GSort : public QGraphicsRectItem {
 
 	public:
 
+	static const int marginDefault;
+
         /** 
           * @brief constructor
           *
@@ -49,7 +51,7 @@ class GSort : public QGraphicsRectItem {
           * @param GVNode the node of the skeleton graph containing layout info
 
           */
-		GSort(SortPtr p, GVNode n);
+		GSort(SortPtr p, GVNode n, qreal width, qreal height);
 
 		~GSort();
 
@@ -165,7 +167,7 @@ class GSort : public QGraphicsRectItem {
           * @brief position of the left top corner of the rectangle representing the sort
           *
           */
-	QPoint leftTopCorner;
+	QPoint* leftTopCorner;
 
         /**
           * @brief size of the rectangle representing the sort

--- a/headers/GSort.h~
+++ b/headers/GSort.h~
@@ -2,6 +2,8 @@
 #include <QGraphicsRectItem>
 #include <QGraphicsTextItem>
 #include <QColor>
+#include <QSize>
+#include <QPoint>
 #include <vector>
 #include "PH.h"
 #include "Sort.h"
@@ -139,9 +141,37 @@ class GSort : public QGraphicsRectItem {
           */
         QPoint geteventPressPoint();
 
+        /**
+          * @brief get the center of the ellipse representing the process
+          *
+          * @return GPoint the center of the ellipse
+          *
+          */
+	QPoint* getLeftTopCornerPoint();
+
+        /**
+          * @brief get the size of the ellipse representing the process
+          *
+          * @return GSize the size of the ellipse
+          *
+          */
+	QSize* getSizeRect();
+
 
 		
 	protected:
+
+        /**
+          * @brief position of the left top corner of the rectangle representing the sort
+          *
+          */
+	QPoint leftTopCorner;
+
+        /**
+          * @brief size of the rectangle representing the sort
+          *
+          */
+	QSize* sizeRect;
 
         /**
           * @brief the graphical item representing the rectangle of the Sort
@@ -162,7 +192,7 @@ class GSort : public QGraphicsRectItem {
 		SortPtr sort;
 
         /**
-          * @brief the related Sort
+          * @brief list of GProcessPtr contained by the sort
 
           *
 

--- a/headers/GVSkeletonGraph.h
+++ b/headers/GVSkeletonGraph.h
@@ -118,6 +118,8 @@ class GVSkeletonGraph {
 		 */	
 		bool hasNode(const QString& name);
 
+		void setNodeSize(void* object, qreal width, qreal height);
+
 		/**
 		 * @brief gets a node by its name
 		 * @param QString name the name of the node to get

--- a/headers/GVSkeletonGraph.h~
+++ b/headers/GVSkeletonGraph.h~
@@ -118,6 +118,8 @@ class GVSkeletonGraph {
 		 */	
 		bool hasNode(const QString& name);
 
+		void setNodeSize(void* object, qreal width, qreal height);
+
 		/**
 		 * @brief gets a node by its name
 		 * @param QString name the name of the node to get

--- a/headers/PHScene.h
+++ b/headers/PHScene.h
@@ -137,7 +137,7 @@ class PHScene: public QGraphicsScene {
           * @brief vector of the Processes drawn in the scene
           *
           */
-		std::vector<GProcessPtr> processes;
+	std::vector<GProcessPtr> processes;
 
         /**
           * @brief vector of the Actions drawn in the scene

--- a/headers/PHScene.h
+++ b/headers/PHScene.h
@@ -151,6 +151,6 @@ class PHScene: public QGraphicsScene {
           * @param GVGraphPtr a smart pointer to the graphviz graph to convert
           *
           */
-        void createActions(GVGraphPtr graph);
+        void createActions();
 
 };

--- a/headers/PHScene.h
+++ b/headers/PHScene.h
@@ -99,6 +99,12 @@ class PHScene: public QGraphicsScene {
         void showActions();
 
         /**
+          * @brief update the position of actions
+          *
+          */
+	void updateAction();
+
+        /**
           * @brief recalculates the graph, functions of customized GSort items positions
           *
           */

--- a/headers/PHScene.h~
+++ b/headers/PHScene.h~
@@ -99,6 +99,12 @@ class PHScene: public QGraphicsScene {
         void showActions();
 
         /**
+          * @brief update the position of actions
+          *
+          */
+	void updateAction()
+
+        /**
           * @brief recalculates the graph, functions of customized GSort items positions
           *
           */
@@ -137,7 +143,7 @@ class PHScene: public QGraphicsScene {
           * @brief vector of the Processes drawn in the scene
           *
           */
-		std::vector<GProcessPtr> processes;
+	std::vector<GProcessPtr> processes;
 
         /**
           * @brief vector of the Actions drawn in the scene

--- a/headers/PHScene.h~
+++ b/headers/PHScene.h~
@@ -26,8 +26,6 @@ using std::string;
 class PH;
 class GProcess;
 typedef boost::shared_ptr<GProcess> GProcessPtr;
-class GSimpleProcess;
-typedef boost::shared_ptr<GSimpleProcess> GSimpleProcessPtr;
 class GSort;
 typedef boost::shared_ptr<GSort> GSortPtr;
 class GAction;

--- a/headers/PHScene.h~
+++ b/headers/PHScene.h~
@@ -151,6 +151,6 @@ class PHScene: public QGraphicsScene {
           * @param GVGraphPtr a smart pointer to the graphviz graph to convert
           *
           */
-        void createActions(GVGraphPtr graph);
+        void createActions();
 
 };

--- a/src/gfx/GAction.cpp
+++ b/src/gfx/GAction.cpp
@@ -44,7 +44,11 @@ GAction::GAction(ActionPtr a, PHScene* sc) : scene(sc), action(a) {
 
     QPoint* targetPointLine = new QPoint(-sizeSource->width()*hitVector->x()+target->getCenterPoint()->x(),sizeSource->height()*hitVector->y()+source->getCenterPoint()->y());
 
-    hitLine = new QLine(*sourcePointLine,*targetPointLine);
+    hitLine = new QGraphicsLineItem(QLine(*sourcePointLine,*targetPointLine),display);
+    hitLine->setPen(QPen(QColor(0,0,0)));
+}
+
+GAction::GAction(){
 }
 
 // Important for the destructor : do not delete scene, it's owned by a shared pointer in PH.h

--- a/src/gfx/GAction.cpp
+++ b/src/gfx/GAction.cpp
@@ -41,10 +41,15 @@ GAction::GAction(ActionPtr a, PHScene* sc) : scene(sc), action(a) {
     QSizeF* sizeSource = source->getSizeEllipse();
     QSizeF* sizeTarget = source->getSizeEllipse();
 
+/*
     QPointF* sourcePointLine = new QPointF(sizeSource->width()*hitVector->x()/2 + source->getCenterPoint()->x(),sizeSource->height()*hitVector->y()/2 + source->getCenterPoint()->y());
 
     QPointF* targetPointLine = new QPointF(-sizeTarget->width()*hitVector->x()/2 + target->getCenterPoint()->x(),-sizeTarget->height()*hitVector->y()/2 + target->getCenterPoint()->y());
+*/
 
+    QPointF* sourcePointLine = new QPointF(source->getCenterPoint()->x(),source->getCenterPoint()->y());
+
+    QPointF* targetPointLine = new QPointF(target->getCenterPoint()->x(),target->getCenterPoint()->y());
     hitLine = new QGraphicsLineItem(QLineF(*targetPointLine,*sourcePointLine),display);
     hitLine->setPen(QPen(QColor(0,0,0)));
 }
@@ -90,6 +95,8 @@ QGraphicsPolygonItem* GAction::makeArrowHead(const GVEdge& e, const QColor& colo
     return res;
 }
 
+void GAction::update(){
+}
 
 // getters
 

--- a/src/gfx/GAction.cpp
+++ b/src/gfx/GAction.cpp
@@ -41,15 +41,15 @@ GAction::GAction(ActionPtr a, PHScene* sc) : scene(sc), action(a) {
     QSizeF* sizeSource = source->getSizeEllipse();
     QSizeF* sizeTarget = source->getSizeEllipse();
 
-/*
+
     QPointF* sourcePointLine = new QPointF(sizeSource->width()*hitVector->x()/2 + source->getCenterPoint()->x(),sizeSource->height()*hitVector->y()/2 + source->getCenterPoint()->y());
 
     QPointF* targetPointLine = new QPointF(-sizeTarget->width()*hitVector->x()/2 + target->getCenterPoint()->x(),-sizeTarget->height()*hitVector->y()/2 + target->getCenterPoint()->y());
-*/
 
+/*
     QPointF* sourcePointLine = new QPointF(source->getCenterPoint()->x(),source->getCenterPoint()->y());
-
     QPointF* targetPointLine = new QPointF(target->getCenterPoint()->x(),target->getCenterPoint()->y());
+*/  
     hitLine = new QGraphicsLineItem(QLineF(*targetPointLine,*sourcePointLine),display);
     hitLine->setPen(QPen(QColor(0,0,0)));
 }

--- a/src/gfx/GAction.cpp
+++ b/src/gfx/GAction.cpp
@@ -34,17 +34,18 @@ GAction::GAction(ActionPtr a, PHScene* sc) : scene(sc), action(a) {
     GProcessPtr source = action->getSource()->getGProcess();
     GProcessPtr target = action->getTarget()->getGProcess();
 
+
     QVector2D* hitVector = new QVector2D(*(target->getCenterPoint()) - *(source->getCenterPoint()));
     hitVector->normalize();
 
-    QSize* sizeSource = source->getSizeEllipse();
-    QSize* sizeTarget = source->getSizeEllipse();
+    QSizeF* sizeSource = source->getSizeEllipse();
+    QSizeF* sizeTarget = source->getSizeEllipse();
 
-    QPoint* sourcePointLine = new QPoint(sizeSource->width()*hitVector->x()+source->getCenterPoint()->x(),sizeSource->height()*hitVector->y()+source->getCenterPoint()->y());
+    QPointF* sourcePointLine = new QPointF(sizeSource->width()*hitVector->x()/2 + source->getCenterPoint()->x(),sizeSource->height()*hitVector->y()/2 + source->getCenterPoint()->y());
 
-    QPoint* targetPointLine = new QPoint(-sizeSource->width()*hitVector->x()+target->getCenterPoint()->x(),sizeSource->height()*hitVector->y()+source->getCenterPoint()->y());
+    QPointF* targetPointLine = new QPointF(-sizeTarget->width()*hitVector->x()/2 + target->getCenterPoint()->x(),-sizeTarget->height()*hitVector->y()/2 + target->getCenterPoint()->y());
 
-    hitLine = new QGraphicsLineItem(QLine(*sourcePointLine,*targetPointLine),display);
+    hitLine = new QGraphicsLineItem(QLineF(*targetPointLine,*sourcePointLine),display);
     hitLine->setPen(QPen(QColor(0,0,0)));
 }
 

--- a/src/gfx/GAction.cpp~
+++ b/src/gfx/GAction.cpp~
@@ -38,13 +38,18 @@ GAction::GAction(ActionPtr a, PHScene* sc) : scene(sc), action(a) {
     QVector2D* hitVector = new QVector2D(*(target->getCenterPoint()) - *(source->getCenterPoint()));
     hitVector->normalize();
 
-    QSize* sizeSource = source->getSizeEllipse();
-    QSize* sizeTarget = source->getSizeEllipse();
+    QSizeF* sizeSource = source->getSizeEllipse();
+    QSizeF* sizeTarget = source->getSizeEllipse();
 
+/*
     QPointF* sourcePointLine = new QPointF(sizeSource->width()*hitVector->x()/2 + source->getCenterPoint()->x(),sizeSource->height()*hitVector->y()/2 + source->getCenterPoint()->y());
 
     QPointF* targetPointLine = new QPointF(-sizeTarget->width()*hitVector->x()/2 + target->getCenterPoint()->x(),-sizeTarget->height()*hitVector->y()/2 + target->getCenterPoint()->y());
+*/
 
+    QPointF* sourcePointLine = new QPointF(source->getCenterPoint()->x(),source->getCenterPoint()->y());
+
+    QPointF* targetPointLine = new QPointF(target->getCenterPoint()->x(),target->getCenterPoint()->y());
     hitLine = new QGraphicsLineItem(QLineF(*targetPointLine,*sourcePointLine),display);
     hitLine->setPen(QPen(QColor(0,0,0)));
 }
@@ -89,6 +94,7 @@ QGraphicsPolygonItem* GAction::makeArrowHead(const GVEdge& e, const QColor& colo
     res->setBrush(QBrush(color));
     return res;
 }
+
 
 
 // getters

--- a/src/gfx/GAction.cpp~
+++ b/src/gfx/GAction.cpp~
@@ -44,7 +44,7 @@ GAction::GAction(ActionPtr a, PHScene* sc) : scene(sc), action(a) {
 
     QPoint* targetPointLine = new QPoint(-sizeSource->width()*hitVector->x()+target->getCenterPoint()->x(),sizeSource->height()*hitVector->y()+source->getCenterPoint()->y());
 
-    hitLine = new QLine(*sourcePointLine,*targetPointLine);
+    hitLine = new QLine(sourcePointLine,targetPointLine);
 }
 
 // Important for the destructor : do not delete scene, it's owned by a shared pointer in PH.h

--- a/src/gfx/GAction.cpp~
+++ b/src/gfx/GAction.cpp~
@@ -44,7 +44,11 @@ GAction::GAction(ActionPtr a, PHScene* sc) : scene(sc), action(a) {
 
     QPoint* targetPointLine = new QPoint(-sizeSource->width()*hitVector->x()+target->getCenterPoint()->x(),sizeSource->height()*hitVector->y()+source->getCenterPoint()->y());
 
-    hitLine = new QLine(sourcePointLine,targetPointLine);
+    hitLine = new QGraphicsLineItem(QLine(*sourcePointLine,*targetPointLine),display);
+    hitLine->setPen(QPen(QColor(7,54,66)));
+}
+
+GAction::GAction(){
 }
 
 // Important for the destructor : do not delete scene, it's owned by a shared pointer in PH.h

--- a/src/gfx/GAction.cpp~
+++ b/src/gfx/GAction.cpp~
@@ -95,7 +95,8 @@ QGraphicsPolygonItem* GAction::makeArrowHead(const GVEdge& e, const QColor& colo
     return res;
 }
 
-
+void GAction::update(){
+}
 
 // getters
 

--- a/src/gfx/GAction.cpp~
+++ b/src/gfx/GAction.cpp~
@@ -34,18 +34,19 @@ GAction::GAction(ActionPtr a, PHScene* sc) : scene(sc), action(a) {
     GProcessPtr source = action->getSource()->getGProcess();
     GProcessPtr target = action->getTarget()->getGProcess();
 
+
     QVector2D* hitVector = new QVector2D(*(target->getCenterPoint()) - *(source->getCenterPoint()));
     hitVector->normalize();
 
     QSize* sizeSource = source->getSizeEllipse();
     QSize* sizeTarget = source->getSizeEllipse();
 
-    QPoint* sourcePointLine = new QPoint(sizeSource->width()*hitVector->x()+source->getCenterPoint()->x(),sizeSource->height()*hitVector->y()+source->getCenterPoint()->y());
+    QPointF* sourcePointLine = new QPointF(sizeSource->width()*hitVector->x()/2 + source->getCenterPoint()->x(),sizeSource->height()*hitVector->y()/2 + source->getCenterPoint()->y());
 
-    QPoint* targetPointLine = new QPoint(-sizeSource->width()*hitVector->x()+target->getCenterPoint()->x(),sizeSource->height()*hitVector->y()+source->getCenterPoint()->y());
+    QPointF* targetPointLine = new QPointF(-sizeTarget->width()*hitVector->x()/2 + target->getCenterPoint()->x(),-sizeTarget->height()*hitVector->y()/2 + target->getCenterPoint()->y());
 
-    hitLine = new QGraphicsLineItem(QLine(*sourcePointLine,*targetPointLine),display);
-    hitLine->setPen(QPen(QColor(7,54,66)));
+    hitLine = new QGraphicsLineItem(QLineF(*targetPointLine,*sourcePointLine),display);
+    hitLine->setPen(QPen(QColor(0,0,0)));
 }
 
 GAction::GAction(){

--- a/src/gfx/GProcess.cpp
+++ b/src/gfx/GProcess.cpp
@@ -52,8 +52,8 @@ GProcess::GProcess(ProcessPtr p,double centerX, double centerY, double width, do
 
 
     // init size of the ellipse and the position of the center
-    size = new QSize(width,height);
-    center = new QPoint(centerX,centerY);
+    size = new QSizeF(width,height);
+    center = new QPointF(centerX,centerY);
 
     // ellipse
     ellipse = new QGraphicsEllipseItem (center->x()-size->width()/2, center->y()-size->height()/2,
@@ -106,9 +106,9 @@ GVNode* GProcess::getNode() { return &(this->node); }
 
 QGraphicsRectItem* GProcess::getMarginRect() { return this->marginRect; }
 
-QPoint* GProcess::getCenterPoint() {return this->center;}
+QPointF* GProcess::getCenterPoint() {return this->center;}
 
-QSize* GProcess::getSizeEllipse() {return this->size;}
+QSizeF* GProcess::getSizeEllipse() {return this->size;}
 
 void GProcess::setNodeCoords(int dx, int dy) {
     node.centerPos.setX(node.centerPos.x() + dx);

--- a/src/gfx/GProcess.cpp
+++ b/src/gfx/GProcess.cpp
@@ -11,7 +11,7 @@
 
 const int GProcess::marginZone  = 10;
 const int GProcess::sortName    = 11;
-
+const int GProcess::sizeDefault = 100;
 
 GProcess::GProcess(ProcessPtr p, GVNode n, qreal graphDPI) : process(p), node(n) {
 
@@ -46,29 +46,29 @@ GProcess::GProcess(ProcessPtr p, GVNode n, qreal graphDPI) : process(p), node(n)
 	text->setPos(text->x() - textSize.width()/2, text->y() - textSize.height()/2);
 }
 
-GProcess::GProcess(ProcessPtr p,double centerX, double centerY, double width, double height) : process(p){
+GProcess::GProcess(ProcessPtr p,double centerX, double centerY) : process(p){
 
     display = new QGraphicsItemGroup();
 
 
     // init size of the ellipse and the position of the center
-    size = new QSizeF(width,height);
+    size = new QSizeF(sizeDefault,sizeDefault);
     center = new QPointF(centerX,centerY);
 
     // ellipse
-    ellipse = new QGraphicsEllipseItem (center->x()-size->width()/2, center->y()-size->height()/2,
+    ellipse = new QGraphicsEllipseItem (center->x()-sizeDefault/2, center->y()-sizeDefault/2,
                                         size->width(), size->height(), display);
 	ellipse->setPen(QPen(QColor(238,232,213)));
 	ellipse->setBrush(QBrush(QColor(238,232,213)));
 
 
-    //int margin( (int) ceil(GVSubGraph::sepValue * graphDPI / GVGraph::DotDefaultDPI) );
-    int margin = 30;
+    int margin(GSort::marginDefault);
+
     marginRect = new QGraphicsRectItem(
-                centerX - margin,
-                centerY - margin,
-                width + 2*margin,
-                height + 2*margin,
+                centerX - margin/2,
+                centerY - margin/2,
+                2*margin,
+                2*margin,
                 display);
                 
     marginRect->setBrush(Qt::NoBrush);

--- a/src/gfx/GProcess.cpp
+++ b/src/gfx/GProcess.cpp
@@ -50,9 +50,14 @@ GProcess::GProcess(ProcessPtr p,double centerX, double centerY, double width, do
 
     display = new QGraphicsItemGroup();
 
+
+    // init size of the ellipse and the position of the center
+    size = new QSize(width,height);
+    center = new QPoint(centerX,centerY);
+
     // ellipse
-    ellipse = new QGraphicsEllipseItem (centerX-width/2, centerY-height/2,
-                                        width, height, display);
+    ellipse = new QGraphicsEllipseItem (center->x()-size->width()/2, center->y()-size->height()/2,
+                                        size->width(), size->height(), display);
 	ellipse->setPen(QPen(QColor(238,232,213)));
 	ellipse->setBrush(QBrush(QColor(238,232,213)));
 
@@ -85,6 +90,8 @@ GProcess::GProcess(ProcessPtr p,double centerX, double centerY, double width, do
 GProcess::~GProcess() {
     delete text;
     delete ellipse;
+    delete center;
+    delete size;
     delete display;
 }
 
@@ -99,6 +106,9 @@ GVNode* GProcess::getNode() { return &(this->node); }
 
 QGraphicsRectItem* GProcess::getMarginRect() { return this->marginRect; }
 
+QPoint* GProcess::getCenterPoint() {return this->center;}
+
+QSize* GProcess::getSizeEllipse() {return this->size;}
 
 void GProcess::setNodeCoords(int dx, int dy) {
     node.centerPos.setX(node.centerPos.x() + dx);

--- a/src/gfx/GProcess.cpp~
+++ b/src/gfx/GProcess.cpp~
@@ -11,7 +11,7 @@
 
 const int GProcess::marginZone  = 10;
 const int GProcess::sortName    = 11;
-
+const int GProcess::sizeDefault = 100;
 
 GProcess::GProcess(ProcessPtr p, GVNode n, qreal graphDPI) : process(p), node(n) {
 
@@ -46,29 +46,29 @@ GProcess::GProcess(ProcessPtr p, GVNode n, qreal graphDPI) : process(p), node(n)
 	text->setPos(text->x() - textSize.width()/2, text->y() - textSize.height()/2);
 }
 
-GProcess::GProcess(ProcessPtr p,double centerX, double centerY, double width, double height) : process(p){
+GProcess::GProcess(ProcessPtr p,double centerX, double centerY) : process(p){
 
     display = new QGraphicsItemGroup();
 
 
     // init size of the ellipse and the position of the center
-    size = new QSize(width,height);
-    center = new QPoint(centerX,centerY);
+    size = new QSizeF(sizeDefault,sizeDefault);
+    center = new QPointF(centerX,centerY);
 
     // ellipse
-    ellipse = new QGraphicsEllipseItem (center->x()-size->width()/2, center->y()-size->height()/2,
+    ellipse = new QGraphicsEllipseItem (center->x()-sizeDefault/2, center->y()-sizeDefault/2,
                                         size->width(), size->height(), display);
 	ellipse->setPen(QPen(QColor(238,232,213)));
 	ellipse->setBrush(QBrush(QColor(238,232,213)));
 
 
-    //int margin( (int) ceil(GVSubGraph::sepValue * graphDPI / GVGraph::DotDefaultDPI) );
-    int margin = 30;
+    int margin(GSort::marginDefault);
+
     marginRect = new QGraphicsRectItem(
-                centerX - margin,
-                centerY - margin,
-                width + 2*margin,
-                height + 2*margin,
+                centerX - margin/2,
+                centerY - margin/2,
+                margin,
+                margin,
                 display);
                 
     marginRect->setBrush(Qt::NoBrush);

--- a/src/gfx/GProcess.cpp~
+++ b/src/gfx/GProcess.cpp~
@@ -50,9 +50,14 @@ GProcess::GProcess(ProcessPtr p,double centerX, double centerY, double width, do
 
     display = new QGraphicsItemGroup();
 
+
+    // init size of the ellipse and the position of the center
+    size = new QSize(width,height);
+    center = new QPoint(centerX,centerY);
+
     // ellipse
-    ellipse = new QGraphicsEllipseItem (centerX-width/2, centerY-height/2,
-                                        width, height, display);
+    ellipse = new QGraphicsEllipseItem (center->x()-size->width()/2, center->y()-size->height()/2,
+                                        size->width(), size->height(), display);
 	ellipse->setPen(QPen(QColor(238,232,213)));
 	ellipse->setBrush(QBrush(QColor(238,232,213)));
 
@@ -83,8 +88,8 @@ GProcess::GProcess(ProcessPtr p,double centerX, double centerY, double width, do
 
 
 GProcess::~GProcess() {
-    delete ellipse;
     delete text;
+    delete ellipse;
     delete display;
 }
 
@@ -99,6 +104,9 @@ GVNode* GProcess::getNode() { return &(this->node); }
 
 QGraphicsRectItem* GProcess::getMarginRect() { return this->marginRect; }
 
+QPoint* GProcess::getCenterPoint() {return this->center;}
+
+QSize* GProcess::getSizeEllipse() {return this->size;}
 
 void GProcess::setNodeCoords(int dx, int dy) {
     node.centerPos.setX(node.centerPos.x() + dx);

--- a/src/gfx/GProcess.cpp~
+++ b/src/gfx/GProcess.cpp~
@@ -90,6 +90,8 @@ GProcess::GProcess(ProcessPtr p,double centerX, double centerY, double width, do
 GProcess::~GProcess() {
     delete text;
     delete ellipse;
+    delete center;
+    delete size;
     delete display;
 }
 
@@ -104,9 +106,9 @@ GVNode* GProcess::getNode() { return &(this->node); }
 
 QGraphicsRectItem* GProcess::getMarginRect() { return this->marginRect; }
 
-QPoint* GProcess::getCenterPoint() {return this->center;}
+QPointF* GProcess::getCenterPoint() {return this->center;}
 
-QSize* GProcess::getSizeEllipse() {return this->size;}
+QSizeF* GProcess::getSizeEllipse() {return this->size;}
 
 void GProcess::setNodeCoords(int dx, int dy) {
     node.centerPos.setX(node.centerPos.x() + dx);

--- a/src/gfx/GSort.cpp
+++ b/src/gfx/GSort.cpp
@@ -14,6 +14,8 @@
 #include "GSort.h"
 #include "Process.h"
 
+const int GSort::marginDefault = 10;
+
 GSort::GSort(SortPtr s, GVCluster c) :
     QGraphicsRectItem(c.topLeft.x(), c.topLeft.y(), c.width, c.height),
     sort(s), cluster(c) {
@@ -39,6 +41,7 @@ GSort::GSort(SortPtr s, GVCluster c) :
 
     // set related GProcesses as children (so they move with this GSort)
     vector<ProcessPtr> processes = sort->getProcesses();
+    
     for (ProcessPtr &process : processes) {
         process->getGProcess()->getDisplayItem()->setParentItem(this);
     }
@@ -46,12 +49,12 @@ GSort::GSort(SortPtr s, GVCluster c) :
 
 }
 
-GSort::GSort(SortPtr s, GVNode n) : QGraphicsRectItem(n.centerPos.x()-n.width/8, n.centerPos.y()-n.height/2, n.width/4, n.height),sort(s), node(n) {
+GSort::GSort(SortPtr s, GVNode n, qreal width, qreal height) : QGraphicsRectItem(n.centerPos.x()-width/2, n.centerPos.y()-height/2, width, height),sort(s), node(n) {
 
     // graphic items set and Actions color
     color = makeColor();
-    sizeRect = new QSize(n.width/4, n.height);
-    sizeRect->width();
+    sizeRect = new QSize(width, height);
+
     leftTopCorner = new QPoint(n.centerPos.x()-sizeRect->width()/2,n.centerPos.y()-sizeRect->height()/2);
 
     // rectangle
@@ -65,7 +68,7 @@ GSort::GSort(SortPtr s, GVNode n) : QGraphicsRectItem(n.centerPos.x()-n.width/8,
     text->setDefaultTextColor(*color);
     text->setPos(leftTopCorner->x()+sizeRect->width()/2, leftTopCorner->y());
     QSizeF textSize = text->document()->size();
-    text->setPos(text->x() - textSize.width()/2, text->y());
+    text->setPos(text->x() - textSize.width()/2, text->y() - textSize.height());
 
     setCursor(QCursor(Qt::OpenHandCursor));
     setAcceptedMouseButtons(Qt::LeftButton | Qt::RightButton);
@@ -73,16 +76,18 @@ GSort::GSort(SortPtr s, GVNode n) : QGraphicsRectItem(n.centerPos.x()-n.width/8,
     // set related GProcesses as children (so they move with this GSort)
     vector<ProcessPtr> processes = sort->getProcesses();
     int nbProcess = processes.size();
-    int currPosYProcess = sizeRect->height()/(1.5*nbProcess);
+    int currPosYProcess = marginDefault+GProcess::sizeDefault/2;
+
     for(ProcessPtr &p : processes){
-	gProcesses.push_back(make_shared<GProcess>(p, leftTopCorner->x() + sizeRect->width()/2, leftTopCorner->y()+ currPosYProcess, sizeRect->width()-10, sizeRect->height()/(nbProcess+1)-30));
-	currPosYProcess+=sizeRect->height()/(nbProcess+1);
+	gProcesses.push_back(make_shared<GProcess>(p, leftTopCorner->x() + GProcess::sizeDefault/2+ marginDefault, leftTopCorner->y()+ currPosYProcess));
+	currPosYProcess+= 2*marginDefault + GProcess::sizeDefault;
     }
     for(GProcessPtr &gp: gProcesses){
 	gp->getDisplayItem()->setParentItem(this);
 	ProcessPtr* p = gp->getProcess();
 	(*p)->setGProcess(gp);
     }
+
 }
 
 GSort::~GSort() {

--- a/src/gfx/GSort.cpp
+++ b/src/gfx/GSort.cpp
@@ -80,6 +80,8 @@ GSort::GSort(SortPtr s, GVNode n) : QGraphicsRectItem(n.centerPos.x()-n.width/8,
     }
     for(GProcessPtr &gp: gProcesses){
 	gp->getDisplayItem()->setParentItem(this);
+	ProcessPtr* p = gp->getProcess();
+	(*p)->setGProcess(gp);
     }
 }
 

--- a/src/gfx/GSort.cpp~
+++ b/src/gfx/GSort.cpp~
@@ -14,6 +14,8 @@
 #include "GSort.h"
 #include "Process.h"
 
+const int GSort::marginDefault = 10;
+
 GSort::GSort(SortPtr s, GVCluster c) :
     QGraphicsRectItem(c.topLeft.x(), c.topLeft.y(), c.width, c.height),
     sort(s), cluster(c) {
@@ -39,6 +41,7 @@ GSort::GSort(SortPtr s, GVCluster c) :
 
     // set related GProcesses as children (so they move with this GSort)
     vector<ProcessPtr> processes = sort->getProcesses();
+    
     for (ProcessPtr &process : processes) {
         process->getGProcess()->getDisplayItem()->setParentItem(this);
     }
@@ -46,12 +49,12 @@ GSort::GSort(SortPtr s, GVCluster c) :
 
 }
 
-GSort::GSort(SortPtr s, GVNode n) : QGraphicsRectItem(n.centerPos.x()-n.width/8, n.centerPos.y()-n.height/2, n.width/4, n.height),sort(s), node(n) {
+GSort::GSort(SortPtr s, GVNode n, qreal width, qreal height) : QGraphicsRectItem(n.centerPos.x()-width/2, n.centerPos.y()-height/2, width, height),sort(s), node(n) {
 
     // graphic items set and Actions color
     color = makeColor();
-    sizeRect = new QSize(n.width/4, n.height);
-    sizeRect->width();
+    sizeRect = new QSize(width, height);
+
     leftTopCorner = new QPoint(n.centerPos.x()-sizeRect->width()/2,n.centerPos.y()-sizeRect->height()/2);
 
     // rectangle
@@ -65,7 +68,7 @@ GSort::GSort(SortPtr s, GVNode n) : QGraphicsRectItem(n.centerPos.x()-n.width/8,
     text->setDefaultTextColor(*color);
     text->setPos(leftTopCorner->x()+sizeRect->width()/2, leftTopCorner->y());
     QSizeF textSize = text->document()->size();
-    text->setPos(text->x() - textSize.width()/2, text->y());
+    text->setPos(text->x() - textSize.width()/2, text->y() - textSize.height());
 
     setCursor(QCursor(Qt::OpenHandCursor));
     setAcceptedMouseButtons(Qt::LeftButton | Qt::RightButton);
@@ -73,16 +76,18 @@ GSort::GSort(SortPtr s, GVNode n) : QGraphicsRectItem(n.centerPos.x()-n.width/8,
     // set related GProcesses as children (so they move with this GSort)
     vector<ProcessPtr> processes = sort->getProcesses();
     int nbProcess = processes.size();
-    int currPosYProcess = sizeRect->height()/(1.5*nbProcess);
+    int currPosYProcess = marginDefault+GProcess::sizeDefault/2;
+
     for(ProcessPtr &p : processes){
-	gProcesses.push_back(make_shared<GProcess>(p, leftTopCorner->x() + sizeRect->width()/2, leftTopCorner->y()+ currPosYProcess, sizeRect->width()-10, sizeRect->height()/(nbProcess+1)-30));
-	currPosYProcess+=sizeRect->height()/(nbProcess+1);
+	gProcesses.push_back(make_shared<GProcess>(p, leftTopCorner->x() + GProcess::sizeDefault/2+ marginDefault, leftTopCorner->y()+ currPosYProcess));
+	currPosYProcess+= 2*marginDefault + GProcess::sizeDefault;
     }
     for(GProcessPtr &gp: gProcesses){
 	gp->getDisplayItem()->setParentItem(this);
 	ProcessPtr* p = gp->getProcess();
-	(*p)->getNumber();
+	(*p)->setGProcess(gp);
     }
+
 }
 
 GSort::~GSort() {

--- a/src/gfx/GSort.cpp~
+++ b/src/gfx/GSort.cpp~
@@ -80,6 +80,8 @@ GSort::GSort(SortPtr s, GVNode n) : QGraphicsRectItem(n.centerPos.x()-n.width/8,
     }
     for(GProcessPtr &gp: gProcesses){
 	gp->getDisplayItem()->setParentItem(this);
+	ProcessPtr* p = gp->getProcess();
+	(*p)->getNumber();
     }
 }
 

--- a/src/gfx/GSort.cpp~
+++ b/src/gfx/GSort.cpp~
@@ -9,6 +9,8 @@
 #include <QDebug>
 #include <QApplication>
 #include <QMenu>
+#include <QPoint>
+#include <QSize>
 #include "GSort.h"
 #include "Process.h"
 
@@ -48,14 +50,12 @@ GSort::GSort(SortPtr s, GVNode n) : QGraphicsRectItem(n.centerPos.x()-n.width/8,
 
     // graphic items set and Actions color
     color = makeColor();
-    double widthRect, heightRect, xCornerPos, yCornerPos;
-    widthRect = n.width/4;
-    heightRect = n.height;
-    xCornerPos = n.centerPos.x()-widthRect/2;
-    yCornerPos = n.centerPos.y()-heightRect/2;
+    sizeRect = new QSize(n.width/4, n.height);
+    sizeRect->width();
+    leftTopCorner = new QPoint(n.centerPos.x()-sizeRect->width()/2,n.centerPos.y()-sizeRect->height()/2);
 
     // rectangle
-    _rect = new QGraphicsRectItem(QRectF(xCornerPos, yCornerPos, widthRect, heightRect),this);
+    _rect = new QGraphicsRectItem(QRectF(*leftTopCorner, *sizeRect),this);
     _rect->setPen(QPen(QColor(7,54,66)));
     _rect->setBrush(QBrush(QColor(7,54,66)));
 
@@ -63,7 +63,7 @@ GSort::GSort(SortPtr s, GVNode n) : QGraphicsRectItem(n.centerPos.x()-n.width/8,
     text = new QGraphicsTextItem (QString(), this);
     text->setHtml(QString::fromStdString("<u>sort " + sort->getName() + "</u>"));
     text->setDefaultTextColor(*color);
-    text->setPos(xCornerPos+widthRect/2, yCornerPos);
+    text->setPos(leftTopCorner->x()+sizeRect->width()/2, leftTopCorner->y());
     QSizeF textSize = text->document()->size();
     text->setPos(text->x() - textSize.width()/2, text->y());
 
@@ -73,21 +73,22 @@ GSort::GSort(SortPtr s, GVNode n) : QGraphicsRectItem(n.centerPos.x()-n.width/8,
     // set related GProcesses as children (so they move with this GSort)
     vector<ProcessPtr> processes = sort->getProcesses();
     int nbProcess = processes.size();
-    int currPosYProcess = heightRect/(1.5*nbProcess);
+    int currPosYProcess = sizeRect->height()/(1.5*nbProcess);
     for(ProcessPtr &p : processes){
-	gProcesses.push_back(make_shared<GProcess>(p, xCornerPos + widthRect/2, yCornerPos+ currPosYProcess, widthRect-10, heightRect/(nbProcess+1)-30));
-	currPosYProcess+=heightRect/(nbProcess+1);
+	gProcesses.push_back(make_shared<GProcess>(p, leftTopCorner->x() + sizeRect->width()/2, leftTopCorner->y()+ currPosYProcess, sizeRect->width()-10, sizeRect->height()/(nbProcess+1)-30));
+	currPosYProcess+=sizeRect->height()/(nbProcess+1);
     }
     for(GProcessPtr &gp: gProcesses){
 	gp->getDisplayItem()->setParentItem(this);
     }
-
 }
 
 GSort::~GSort() {
-    //gProcesses.clear();
-    //delete _rect;
-    //delete text;   
+    gProcesses.clear();
+    delete _rect;
+    delete leftTopCorner;
+    delete sizeRect;
+    delete text;   
 }
 
 // mouse press event handler: start "drag"
@@ -180,7 +181,9 @@ QGraphicsTextItem* GSort::getText() { return this->text; }
 
 QPoint GSort::geteventPressPoint() { return this->eventPressPoint; }
 
+QPoint* GSort::getLeftTopCornerPoint() {return this->leftTopCorner;}
 
+QSize* GSort::getSizeRect() { return this->sizeRect;}
 
 void GSort::updatePosition() {
 

--- a/src/gfx/PHScene.cpp
+++ b/src/gfx/PHScene.cpp
@@ -45,7 +45,7 @@ void PHScene::doRender(void) {
                 sorts.insert(GSortEntry(s->getName(), make_shared<GSort>(s, gc)));
 
     // create GActions linking actual actions to GVEdges (display info)
-    createActions(graph);
+    createActions();
 
     draw();
 }
@@ -65,6 +65,10 @@ void PHScene::drawFromSkeleton(void){
 	clear();
     	for (auto &s : sorts){
         	addItem(s.second.get());
+	}
+
+	for (auto &a : actions){
+	
 	}
 }
 
@@ -148,7 +152,7 @@ void PHScene::updateGraph() {
 
     // create GActions linking actual actions to GVEdges (display info)
     actions.clear();
-    createActions(graph);
+    createActions();
 
     for (GActionPtr &a : actions)
         addItem(a->getDisplayItem());
@@ -175,7 +179,7 @@ void PHScene::updateGraphForImport() {
 
     // create GActions linking actual actions to GVEdges (display info)
     actions.clear();
-    createActions(graph);
+    createActions();
 
 
     for (GActionPtr &a : actions)
@@ -187,37 +191,10 @@ void PHScene::updateGraphForImport() {
 }
 
 
-void PHScene::createActions(GVGraphPtr graph) {
-
-    // retrieve list of GVEdge structs from graphviz geometry data
-    QList<GVEdge> gEdges = graph->edges();
-
+void PHScene::createActions() {
     // create GAction items
-    using std::pair;
-    pair<GVEdge*, GVEdge*> edges;
     for (ActionPtr &a : ph->getActions()) {
-        edges.first = NULL;
-        edges.second = NULL;
-
-        // find graph edges that match the Action
-        for (GVEdge &gEdge : gEdges) {
-
-            // check the hit of the Action
-            if 	(	makeProcessName(a->getSource()) == gEdge.source
-                &&	makeProcessName(a->getTarget()) == gEdge.target
-                ) 	edges.first = &gEdge;
-
-            // check the bounce (result) of the Action
-            if 	(	makeProcessName(a->getTarget()) == gEdge.source
-                &&	makeProcessName(a->getResult()) == gEdge.target
-                ) 	edges.second = &gEdge;
-
-            // if match, add Action to objects to be drawn
-            if (edges.first != NULL && edges.second != NULL) {
-                actions.push_back(make_shared<GAction>(a, *(edges.first), *(edges.second), this));
-                break;
-            }
-        }
+    	actions.push_back(make_shared<GAction>(a, this));
     }
 
 }

--- a/src/gfx/PHScene.cpp
+++ b/src/gfx/PHScene.cpp
@@ -67,9 +67,12 @@ void PHScene::drawFromSkeleton(void){
         	addItem(s.second.get());
 	}
 
+        createActions();
+
 	for (auto &a : actions){
-	
+		addItem(a->getDisplayItem());
 	}
+
 }
 
 // draw all the elements of the scene
@@ -194,7 +197,7 @@ void PHScene::updateGraphForImport() {
 void PHScene::createActions() {
     // create GAction items
     for (ActionPtr &a : ph->getActions()) {
-    	actions.push_back(make_shared<GAction>(a, this));
+    	actions.push_back(make_shared<GAction>(a,this));
     }
 
 }

--- a/src/gfx/PHScene.cpp
+++ b/src/gfx/PHScene.cpp
@@ -56,8 +56,11 @@ void PHScene::drawFromSkeleton(void){
 	QList<GVNode> gSkeletonNodes = gSkeleton->nodes();
 	for(GVNode &gn : gSkeletonNodes){
 		for(SortPtr &s : ph->getSorts()){
+			int nbProcess = (s->getProcesses()).size();
+			int width = GProcess::sizeDefault+2*GSort::marginDefault;
+			int height = nbProcess*(GProcess::sizeDefault+2*GSort::marginDefault);
 			if(gn.name == makeSkeletonNodeName(s->getName())){
-				sorts.insert(GSortEntry(s->getName(), make_shared<GSort>(s,gn)));			
+				sorts.insert(GSortEntry(s->getName(), make_shared<GSort>(s,gn,width,height)));			
 			}
 		}	
 	}
@@ -72,7 +75,6 @@ void PHScene::drawFromSkeleton(void){
 	for (auto &a : actions){
 		addItem(a->getDisplayItem());
 	}
-
 }
 
 // draw all the elements of the scene

--- a/src/gfx/PHScene.cpp
+++ b/src/gfx/PHScene.cpp
@@ -116,6 +116,10 @@ void PHScene::hideActions() {
     }
 }
 
+void PHScene::updateAction(){
+
+}
+
 
 void PHScene::showActions() {
 

--- a/src/gfx/PHScene.cpp~
+++ b/src/gfx/PHScene.cpp~
@@ -56,8 +56,11 @@ void PHScene::drawFromSkeleton(void){
 	QList<GVNode> gSkeletonNodes = gSkeleton->nodes();
 	for(GVNode &gn : gSkeletonNodes){
 		for(SortPtr &s : ph->getSorts()){
+			int nbProcess = s->getProcesses()->size();
+			int width = GProcess::sizeDefault+2*GSort::marginDefault;
+			int height = nbProcess*(GProcess::sizeDefault+2*GSort::marginDefault);
 			if(gn.name == makeSkeletonNodeName(s->getName())){
-				sorts.insert(GSortEntry(s->getName(), make_shared<GSort>(s,gn)));			
+				sorts.insert(GSortEntry(s->getName(), make_shared<GSort>(s,gn,width,height)));			
 			}
 		}	
 	}
@@ -72,7 +75,6 @@ void PHScene::drawFromSkeleton(void){
 	for (auto &a : actions){
 		addItem(a->getDisplayItem());
 	}
-
 }
 
 // draw all the elements of the scene

--- a/src/gfx/PHScene.cpp~
+++ b/src/gfx/PHScene.cpp~
@@ -67,9 +67,12 @@ void PHScene::drawFromSkeleton(void){
         	addItem(s.second.get());
 	}
 
-	for (auto &a : action){
-	
+        createActions();
+/*
+	for (auto &a : actions){
+		addItem(a->getDisplayItem());
 	}
+*/
 }
 
 // draw all the elements of the scene
@@ -194,7 +197,7 @@ void PHScene::updateGraphForImport() {
 void PHScene::createActions() {
     // create GAction items
     for (ActionPtr &a : ph->getActions()) {
-    	actions.push_back(make_shared<GAction>(a, this));
+    	actions.push_back(make_shared<GAction>(a,this));
     }
 
 }

--- a/src/gfx/PHScene.cpp~
+++ b/src/gfx/PHScene.cpp~
@@ -45,7 +45,7 @@ void PHScene::doRender(void) {
                 sorts.insert(GSortEntry(s->getName(), make_shared<GSort>(s, gc)));
 
     // create GActions linking actual actions to GVEdges (display info)
-    createActions(graph);
+    createActions();
 
     draw();
 }
@@ -61,10 +61,14 @@ void PHScene::drawFromSkeleton(void){
 			}
 		}	
 	}
-	// Clear the scene and draw sorts
+	// Clear the scene and add sorts item (containing also processes) to the scene
 	clear();
     	for (auto &s : sorts){
         	addItem(s.second.get());
+	}
+
+	for (auto &a : action){
+	
 	}
 }
 
@@ -148,7 +152,7 @@ void PHScene::updateGraph() {
 
     // create GActions linking actual actions to GVEdges (display info)
     actions.clear();
-    createActions(graph);
+    createActions();
 
     for (GActionPtr &a : actions)
         addItem(a->getDisplayItem());
@@ -175,7 +179,7 @@ void PHScene::updateGraphForImport() {
 
     // create GActions linking actual actions to GVEdges (display info)
     actions.clear();
-    createActions(graph);
+    createActions();
 
 
     for (GActionPtr &a : actions)
@@ -187,37 +191,10 @@ void PHScene::updateGraphForImport() {
 }
 
 
-void PHScene::createActions(GVGraphPtr graph) {
-
-    // retrieve list of GVEdge structs from graphviz geometry data
-    QList<GVEdge> gEdges = graph->edges();
-
+void PHScene::createActions() {
     // create GAction items
-    using std::pair;
-    pair<GVEdge*, GVEdge*> edges;
     for (ActionPtr &a : ph->getActions()) {
-        edges.first = NULL;
-        edges.second = NULL;
-
-        // find graph edges that match the Action
-        for (GVEdge &gEdge : gEdges) {
-
-            // check the hit of the Action
-            if 	(	makeProcessName(a->getSource()) == gEdge.source
-                &&	makeProcessName(a->getTarget()) == gEdge.target
-                ) 	edges.first = &gEdge;
-
-            // check the bounce (result) of the Action
-            if 	(	makeProcessName(a->getTarget()) == gEdge.source
-                &&	makeProcessName(a->getResult()) == gEdge.target
-                ) 	edges.second = &gEdge;
-
-            // if match, add Action to objects to be drawn
-            if (edges.first != NULL && edges.second != NULL) {
-                actions.push_back(make_shared<GAction>(a, *(edges.first), *(edges.second), this));
-                break;
-            }
-        }
+    	actions.push_back(make_shared<GAction>(a, this));
     }
 
 }

--- a/src/gfx/PHScene.cpp~
+++ b/src/gfx/PHScene.cpp~
@@ -68,11 +68,11 @@ void PHScene::drawFromSkeleton(void){
 	}
 
         createActions();
-/*
+
 	for (auto &a : actions){
 		addItem(a->getDisplayItem());
 	}
-*/
+
 }
 
 // draw all the elements of the scene
@@ -114,6 +114,10 @@ void PHScene::hideActions() {
     for (GActionPtr &action : actions) {
         action->getDisplayItem()->hide();
     }
+}
+
+void PHScene::updateAction(){
+
 }
 
 

--- a/src/gviz/GVSkeletonGraph.cpp
+++ b/src/gviz/GVSkeletonGraph.cpp
@@ -7,8 +7,8 @@
 #include "GVSkeletonGraph.h"
 
 const qreal GVSkeletonGraph::DotDefaultDPI=72.0;
-const qreal GVSkeletonGraph::nodeSize = 400;
-const qreal GVSkeletonGraph::sepValue = 2000.0;
+const qreal GVSkeletonGraph::nodeSize = 1;
+const qreal GVSkeletonGraph::sepValue = 30.0;
 
 // Utils
 
@@ -56,9 +56,6 @@ void GVSkeletonGraph::setGraphAttributes(){
 	setGraphObjectAttributes(_graph,"dpi","96,0");
 	QString strSepValue = QString::number(sepValue).prepend("+");
 	setGraphObjectAttributes(_graph, "sep", strSepValue);
-	
-	QString nodePtsWidth = QString("%1").arg(GVSkeletonGraph::nodeSize/_agget(_graph,"dpi", "96,0").replace(',',".").toDouble());
-	_agnodeattr(_graph, "width", nodePtsWidth.replace('.',","));
 }
 
 void GVSkeletonGraph::setGraphObjectAttributes(void *object, QString attr, QString value){
@@ -124,6 +121,13 @@ bool GVSkeletonGraph::hasNode(const QString& name){
 Agnode_t* GVSkeletonGraph::getNode(const QString& name){
 	if(_nodes.contains(name)) return _nodes[name];
 	return NULL;
+}
+
+void GVSkeletonGraph::setNodeSize(void* object, qreal width, qreal height){
+	QString nodePtsWidth = QString("%1").arg(width/_agget(_graph,"dpi", "96,0").replace(',',".").toDouble());
+	setGraphObjectAttributes(object,"width",nodePtsWidth.replace('.',","));
+	QString nodePtsHeight = QString("%1").arg(height/_agget(_graph,"dpi", "96,0").replace(',',".").toDouble());
+	setGraphObjectAttributes(object,"height",nodePtsHeight.replace('.',","));
 }
 
 void GVSkeletonGraph::clearNodes(){

--- a/src/gviz/GVSkeletonGraph.cpp~
+++ b/src/gviz/GVSkeletonGraph.cpp~
@@ -7,8 +7,8 @@
 #include "GVSkeletonGraph.h"
 
 const qreal GVSkeletonGraph::DotDefaultDPI=72.0;
-const qreal GVSkeletonGraph::nodeSize = 400;
-const qreal GVSkeletonGraph::sepValue = 2000.0;
+const qreal GVSkeletonGraph::nodeSize = 1;
+const qreal GVSkeletonGraph::sepValue = 20.0;
 
 // Utils
 
@@ -56,9 +56,6 @@ void GVSkeletonGraph::setGraphAttributes(){
 	setGraphObjectAttributes(_graph,"dpi","96,0");
 	QString strSepValue = QString::number(sepValue).prepend("+");
 	setGraphObjectAttributes(_graph, "sep", strSepValue);
-	
-	QString nodePtsWidth = QString("%1").arg(GVSkeletonGraph::nodeSize/_agget(_graph,"dpi", "96,0").replace(',',".").toDouble());
-	_agnodeattr(_graph, "width", nodePtsWidth.replace('.',","));
 }
 
 void GVSkeletonGraph::setGraphObjectAttributes(void *object, QString attr, QString value){
@@ -73,6 +70,11 @@ void GVSkeletonGraph::setFont(QFont font){
 void GVSkeletonGraph::applyLayout(){
 	gvFreeLayout(_context, _graph);
 	_gvLayout(_context, _graph, "dot");
+}
+
+
+void GVSkeletonGraph::exportToPng() {
+	gvRenderFilename(_context,_graph,"png","out.png");
 }
 
 // Node management
@@ -121,6 +123,13 @@ Agnode_t* GVSkeletonGraph::getNode(const QString& name){
 	return NULL;
 }
 
+void GVSkeletonGraph::setNodeSize(void* object, qreal width, qreal height){
+	QString nodePtsWidth = QString("%1").arg(width/_agget(_graph,"dpi", "96,0").replace(',',".").toDouble());
+	setGraphObjectAttributes(object,"width",nodePtsWidth.replace('.',","));
+	QString nodePtsHeight = QString("%1").arg(height/_agget(_graph,"dpi", "96,0").replace(',',".").toDouble());
+	setGraphObjectAttributes(object,"height",nodePtsHeight.replace('.',","));
+}
+
 void GVSkeletonGraph::clearNodes(){
 	QList<QString> keys = _nodes.keys();
 	for(int i=0;i<keys.size();++i){
@@ -161,6 +170,3 @@ qreal GVSkeletonGraph::getDPI(){
 
 Agraph_t* GVSkeletonGraph::graph() {return this->_graph;}
 
-void GVSkeletonGraph::exportToPng() {
-	gvRenderFilename(_context,_graph,"png","out.png");
-}

--- a/src/ph/PH.cpp
+++ b/src/ph/PH.cpp
@@ -117,13 +117,15 @@ GVSkeletonGraphPtr PH::createSkeletonGraph(void){
 	GVSkeletonGraphPtr gSkeleton = make_shared<GVSkeletonGraph>(QString("Skeleton Graph"));
 	QString sortName;
         vector<ProcessPtr> listProcess;
-        QString nbProcess;
+        int nbProcess;
 	for(auto &e : sorts){
 		sortName = makeSkeletonNodeName(e.second->getName());
 		listProcess = e.second->getProcesses();
-		nbProcess = QString::number(listProcess.size());
+		nbProcess = listProcess.size();
+		int width = GProcess::sizeDefault+2*GSort::marginDefault;
+		int height = nbProcess*(GProcess::sizeDefault+2*GSort::marginDefault);
 		gSkeleton->addNode(sortName);
-		gSkeleton->setGraphObjectAttributes(gSkeleton->getNode(sortName),"height",nbProcess);
+		gSkeleton->setNodeSize(gSkeleton->getNode(sortName),width,height);
 		gSkeleton->setGraphObjectAttributes(gSkeleton->getNode(sortName),"fixedsize","true");
 	}
 	
@@ -135,6 +137,7 @@ GVSkeletonGraphPtr PH::createSkeletonGraph(void){
 		}
 	}
 	gSkeleton->applyLayout();
+
 
 	return gSkeleton;
 }

--- a/src/ph/PH.cpp~
+++ b/src/ph/PH.cpp~
@@ -117,13 +117,15 @@ GVSkeletonGraphPtr PH::createSkeletonGraph(void){
 	GVSkeletonGraphPtr gSkeleton = make_shared<GVSkeletonGraph>(QString("Skeleton Graph"));
 	QString sortName;
         vector<ProcessPtr> listProcess;
-        QString nbProcess;
+        int nbProcess;
 	for(auto &e : sorts){
 		sortName = makeSkeletonNodeName(e.second->getName());
 		listProcess = e.second->getProcesses();
-		nbProcess = QString::number(listProcess.size());
+		nbProcess = listProcess.size();
+		int width = GProcess::sizeDefault+3*GSort::marginDefault;
+		int height = nbProcess*(GProcess::sizeDefault+3*GSort::marginDefault);
 		gSkeleton->addNode(sortName);
-		gSkeleton->setGraphObjectAttributes(gSkeleton->getNode(sortName),"height",nbProcess);
+		gSkeleton->setNodeSize(gSkeleton->getNode(sortName),width,height);
 		gSkeleton->setGraphObjectAttributes(gSkeleton->getNode(sortName),"fixedsize","true");
 	}
 	
@@ -136,7 +138,6 @@ GVSkeletonGraphPtr PH::createSkeletonGraph(void){
 	}
 	gSkeleton->applyLayout();
 
-        gSkeleton->exportToPng();
 
 	return gSkeleton;
 }


### PR DESCRIPTION
DONE
- GProcess et GSort sizes set in function of GProcess::sizeDefault and GSort::marginDefault
- GProcess represented by circle
- First part of action drawn

TODO
- Adjust margin between nodes for GraphViz
- Update actions when a sort is moving
- Draw the second part of actions
- Deal with two sorts overlapping when moving one sort
- Clean the code to remove the old solution
