### PR TITLE
Installing millisecond-sensitive timer

### DIFF
--- a/src/ui/Area.cpp
+++ b/src/ui/Area.cpp
@@ -315,7 +315,8 @@ void Area::saveEdit(int del){
             emit makeTempXML();
         }
 
-//TODO understand why importXMLMetadata after rendering makes actions mad when updating text area... Bug in updating actions ?
+/*TODO understand why importXMLMetadata after rendering makes actions mad when updating text area... Bug in updating actions ?
+Is it useful to call that method here ? */
         this->mainWindow->importXMLMetadata(fileXML);
 
         // render graph

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -290,8 +290,8 @@ MyArea* MainWindow::openTab() {
 
                 try {
                     std::ofstream logFile("log_rendering_time.txt",std::ios::app);
-		    time_t depart, arrivee;
-		    time(&depart);
+            timespec depart, arrivee;
+            clock_gettime(CLOCK_REALTIME,&depart);
                     // render graph
                     PHPtr myPHPtr = PHIO::parseFile(path);
                     area->myArea->setPHPtr(myPHPtr);
@@ -322,11 +322,12 @@ MyArea* MainWindow::openTab() {
 
                     mb->close();
                     this->setWindowState(Qt::WindowMaximized);
-                    time(&arrivee);
+                    // putting time needed to open ph file into a "log_rendering_time.txt" file
+                    clock_gettime(CLOCK_REALTIME,&arrivee);
 		    double timeRendering;
-                    timeRendering = difftime(arrivee,depart);
+            timeRendering = (arrivee.tv_nsec - depart.tv_nsec)/1000000.0+(arrivee.tv_sec - depart.tv_sec)*1000.0;
             logFile << file.toStdString()+"-----"+"-----" << timeRendering;
-                    logFile << " s\n";
+                    logFile << " ms\n";
                     logFile.close();
                     return area->myArea;
 


### PR DESCRIPTION
Opening file timer now displays milliseconds to compare old and new application performances
