### PR TITLE
Corrected sort's border color when changing display mode

### DIFF
--- a/src/gfx/GSort.cpp
+++ b/src/gfx/GSort.cpp
@@ -196,6 +196,11 @@ bool GSort::getSimpleDisplay(){ return this->simpleDisplay; }
 
 void GSort::setSimpleDisplay(bool isSimpleDisplay){
 	this->simpleDisplay = isSimpleDisplay;
+    if(isSimpleDisplay){
+        _rect->setPen(QPen(QColor(255,0,0)));
+    }else{
+        _rect->setPen(QPen(QColor(0,0,0)));
+    }
 }
 
 void GSort::changeDisplayState(){

--- a/src/gfx/GSort.cpp
+++ b/src/gfx/GSort.cpp
@@ -195,11 +195,8 @@ bool GSort::getSimpleDisplay(){ return this->simpleDisplay; }
 
 
 void GSort::setSimpleDisplay(bool isSimpleDisplay){
-	this->simpleDisplay = isSimpleDisplay;
-    if(isSimpleDisplay){
-        _rect->setPen(QPen(QColor(255,0,0)));
-    }else{
-        _rect->setPen(QPen(QColor(0,0,0)));
+    if(this->simpleDisplay != isSimpleDisplay){
+        this->changeDisplayState();
     }
 }
 
@@ -209,7 +206,7 @@ void GSort::changeDisplayState(){
         _rect->setBrush(QBrush(QColor(255,255,255)));
     }else{
 	simpleDisplay = true;
-    _rect->setBrush(QBrush(QColor(255,225,225)));
+    _rect->setBrush(QBrush(QColor(255,190,190)));
     }
     dynamic_cast<PHScene*>(scene())->updateActions();
 }


### PR DESCRIPTION
The border color didn't change when using the global item "switch to detailled/simplified display", only when double-clicking on one sort, it's fixed now.
