### PR TITLE
Bounds are the same at the opening of the file and after a change.

### DIFF
--- a/src/gfx/GAction.cpp
+++ b/src/gfx/GAction.cpp
@@ -137,7 +137,7 @@ void GAction::initPointsNormalHit(){
 
 	targetPoint = new QPointF(-sizeTarget->width()*hitVector->x()/2.0 + target->getCenterPoint()->x(),-sizeTarget->height()*hitVector->y()/2 + target->getCenterPoint()->y());
 
-	resultPoint = new QPointF(-sizeTarget->width()*hitVector->x()/2.0 + result->getCenterPoint()->x(),sizeTarget->height()*hitVector->y()/2 + result->getCenterPoint()->y());
+    resultPoint = new QPointF(-sizeTarget->width()*hitVector->x()/2.0 + result->getCenterPoint()->x(),-sizeTarget->height()*hitVector->y()/2 + result->getCenterPoint()->y());
 
 }
 


### PR DESCRIPTION
There was a difference between initPointsNormalHit() and updatePointsNormalHit() so some bounds changed after the first call to update().
